### PR TITLE
Fix date picker allowing past dates

### DIFF
--- a/main.js
+++ b/main.js
@@ -3955,6 +3955,12 @@
   function patchDatePicker() {
     const install = (input) => {
       if (!input || input.dataset.bnTomorrowInstalled) return;
+      const tomorrow = tomorrowISO();
+      input.min = tomorrow;
+      if (input.value < tomorrow) input.value = tomorrow;
+      input.addEventListener('change', () => {
+        if (input.value < tomorrow) input.value = tomorrow;
+      });
       input.dataset.bnTomorrowInstalled = '1';
     };
     document.addEventListener('focusin', (e) => {


### PR DESCRIPTION
## Summary
- ensure date picker enforces tomorrow or later and fixes value when user selects past date

## Testing
- `node --check main.js`


------
https://chatgpt.com/codex/tasks/task_b_68a2c7a3264483269f33958475e09a28