### PR TITLE
Ensure configuration save triggers page refresh

### DIFF
--- a/main.js
+++ b/main.js
@@ -932,8 +932,13 @@ window.getCurrentUserId = getCurrentUserId;
     // Reload the page to apply the updated configuration
     setTimeout(() => {
       const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;
-      const loc = w.top?.location || w.location;
-      loc.reload();
+      const target = w.top || w;
+      try {
+        target.location.reload();
+      } catch (e) {
+        // Fallback: force navigation if reload is blocked
+        target.location.href = target.location.href;
+      }
     }, 50);
   };
 

--- a/main.js
+++ b/main.js
@@ -931,7 +931,9 @@ window.getCurrentUserId = getCurrentUserId;
 
     // Reload the page to apply the updated configuration
     setTimeout(() => {
-      (typeof unsafeWindow !== 'undefined' ? unsafeWindow : window).location.reload();
+      const w = typeof unsafeWindow !== 'undefined' ? unsafeWindow : window;
+      const loc = w.top?.location || w.location;
+      loc.reload();
     }, 50);
   };
 

--- a/main.js
+++ b/main.js
@@ -929,7 +929,10 @@ window.getCurrentUserId = getCurrentUserId;
     GM_setValue('userPalette', JSON.stringify(obj));
     GM_setValue('useCustomColors', chkUseColor.checked);
 
-    setTimeout(() => location.reload(), 50);
+    // Reload the page to apply the updated configuration
+    setTimeout(() => {
+      (typeof unsafeWindow !== 'undefined' ? unsafeWindow : window).location.reload();
+    }, 50);
   };
 
   document.getElementById('bn-cancel-changes').onclick = () => {


### PR DESCRIPTION
## Summary
- Reload page after saving configuration to apply updated settings immediately

## Testing
- `node -c main.js`


------
https://chatgpt.com/codex/tasks/task_b_68a65e71494083249272d55a8c3aec7f