### PR TITLE
fix: unify submission guard solved detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/main.js
+++ b/main.js
@@ -4568,945 +4568,348 @@ window.getCurrentUserId = getCurrentUserId;
 
 })();
 
-/* =================================================================
- *  六、提交记录页守护（未通过题目 → 弹出“是否继续”提示）
- * ================================================================= */
-(function () {
+/* === Unified Submission Guard (self+100pt single source) === */
+(function (global) {
   'use strict';
-  try {
-    if (!/\/submissions(\/|$)/.test(location.pathname)) return;
 
-    const CFG = { base: location.origin };
+  if (!global || typeof global !== 'object') { return; }
+  if (global.__bnUseUnifiedGuard === false) { return; }
 
-    // 轻量选择器
-    const $ = (s, r) => (r || document).querySelector(s);
+  const TTL_MS = 5 * 60 * 1000;
+  const FALLBACK_TTL_MS = 2 * 60 * 1000;
+  const solveCache = new Map();
+  const inFlight = new Map();
 
-    // 统一 GM_xhr（脚本前面已有 gmFetch，若不可用则降级到 fetch）
-    const gmFetch = (opts) => new Promise((res, rej) => {
-      try {
-        if (typeof GM_xmlhttpRequest === 'function') {
-          GM_xmlhttpRequest({
-            ...opts,
-            withCredentials: true,
-            onload: r => res(r),
-            onerror: e => rej(new Error(e.error || '网络错误'))
-          });
-        } else {
-          fetch(opts.url, { method: opts.method || 'GET', credentials: 'include' })
-            .then(r => r.text().then(t => res({ status: r.status, responseText: t })))
-            .catch(err => rej(err));
-        }
-      } catch (err) { rej(err); }
-    });
-
-
-
-    function ensureModal() {
-      var IN_DURATION = 420;
-      var OUT_DURATION = 420;
-      var EASE_BOX = 'cubic-bezier(.2,.8,.2,1)';
-      var SCALE_FROM = 0.88;
-
-      // 强制全屏 & 居中，避免被站内样式拉到左上
-      if (!document.getElementById('bn-center-css')) {
-        var cs = document.createElement('style');
-        cs.id = 'bn-center-css';
-        cs.textContent = [
-          '#bn-guard-mask{position:fixed!important;inset:0!important;left:0!important;top:0!important;right:0!important;bottom:0!important;display:flex!important;align-items:center!important;justify-content:center!important;z-index:2147483647!important;pointer-events:auto!important;}',
-          '#bn-guard-box{position:static!important;top:auto!important;left:auto!important;margin:0!important;}'
-        ].join('\n');
-        document.head.appendChild(cs);
-      }
-
-      // 构建 DOM（保持站内结构/类名）
-      var mask = document.getElementById('bn-guard-mask');
-      if (!mask) {
-        mask = document.createElement('div');
-        mask.id = 'bn-guard-mask';
-        document.body.appendChild(mask);
-      }
-      mask.className = 'ui dimmer modals page transition visible active';
-      mask.style.display = 'flex';
-      try { document.body.classList.add('dimmed'); } catch (e) { }
-      mask.innerHTML = '';
-
-      var modal = document.createElement('div');
-      modal.id = 'bn-guard-box';
-      modal.className = 'ui basic modal check-need-modal transition visible active';
-      modal.style.position = 'static';
-      modal.style.margin = '0';
-
-      var header = document.createElement('div');
-      header.className = 'ui icon header';
-      var icon = document.createElement('i'); icon.className = 'exclamation triangle icon';
-      header.appendChild(icon);
-      header.appendChild(document.createTextNode('是否继续'));
-
-      var content = document.createElement('div');
-      content.className = 'content';
-      content.textContent = '未通过题目前查看他人答案将获得较低的评级，请经过深入思考以后，确实难以解决再选择查看。';
-
-      var actions = document.createElement('div');
-      actions.className = 'actions';
-      var ok = document.createElement('a'); ok.className = 'ui red ok inverted button'; ok.textContent = '确认';
-      // 关键：取消按钮不要含 ok/approve/deny，避免被 Semantic UI 接管
-      var cancel = document.createElement('button'); cancel.type = 'button';
-      cancel.className = 'ui green inverted button bn-cancel';
-      cancel.textContent = '取消';
-      actions.appendChild(ok); actions.appendChild(cancel);
-
-      modal.appendChild(header); modal.appendChild(content); modal.appendChild(actions);
-      mask.appendChild(modal);
-
-      // 捕获阶段阻断站内委托（只作用于本弹窗内部），避免立即关闭导致看不到动画
-      function captureBlocker(ev) {
-        // 只在我们这个弹窗内部拦截“无关点击”，放行确认和取消
-        if (modal.contains(ev.target)) {
-          // 放行确认按钮
-          if (ev.target === ok) return;
-          // 放行取消按钮（带 .bn-cancel 的元素或其子元素）
-          if (ev.target.closest && ev.target.closest('.bn-cancel')) return;
-
-          // 其它点击才拦截，避免被站内委托（Semantic UI）抢走
-          ev.preventDefault();
-          ev.stopPropagation();
-          ev.stopImmediatePropagation();
-        }
-      }
-
-      document.addEventListener('click', captureBlocker, true);
-
-      // 工具
-      var supportsWAAPI = typeof modal.animate === 'function';
-      var animatingIn = true;
-      var closing = false;
-      actions.style.pointerEvents = 'none';
-
-      function cleanup() {
-        try { document.removeEventListener('click', captureBlocker, true); } catch (e) { }
-        try { mask.remove(); } catch (e) { }
-        try { document.body.classList.remove('dimmed'); } catch (e) { }
-        if (mask.dataset) delete mask.dataset.bnHref;
-        delete window.__bnConfirmCb;
-      }
-      function onTransitionEndOnce(el, cb, timeout) {
-        var done = false;
-        function finish() { if (done) return; done = true; try { el.removeEventListener('transitionend', handler); } catch (e) { }; cb && cb(); }
-        function handler(ev) { if (ev && ev.target !== el) return; finish(); }
-        el.addEventListener('transitionend', handler);
-        setTimeout(finish, typeof timeout === 'number' ? timeout : 600);
-      }
-      function finished(anim, timeout) {
-        return new Promise(function (resolve) {
-          var done = false; function fin() { if (done) return; done = true; resolve(); }
-          if (anim && anim.finished && typeof anim.finished.then === 'function') anim.finished.then(fin).catch(fin);
-          else setTimeout(fin, timeout || 600);
-        });
-      }
-
-      // 入场
-      function animateIn() {
-        mask.style.backgroundColor = 'rgba(0,0,0,0)';
-        modal.style.transformOrigin = 'center center';
-        if (supportsWAAPI) {
-          var maskIn = mask.animate(
-            [{ backgroundColor: 'rgba(0,0,0,0)' }, { backgroundColor: 'rgba(0,0,0,0.85)' }],
-            { duration: IN_DURATION, easing: 'ease', fill: 'forwards' }
-          );
-          var boxIn = modal.animate(
-            [{ transform: 'scale(' + SCALE_FROM + ')', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
-            { duration: IN_DURATION, easing: EASE_BOX, fill: 'forwards' }
-          );
-          Promise.all([finished(maskIn, IN_DURATION + 80), finished(boxIn, IN_DURATION + 80)]).then(function () {
-            animatingIn = false; actions.style.pointerEvents = '';
-          });
-        } else {
-          modal.style.transition = 'transform ' + IN_DURATION + 'ms ' + EASE_BOX + ', opacity ' + IN_DURATION + 'ms ease';
-          mask.style.transition = 'background-color ' + IN_DURATION + 'ms ease';
-          modal.style.transform = 'scale(' + SCALE_FROM + ')'; modal.style.opacity = '0';
-          void modal.offsetHeight;
-          requestAnimationFrame(function () {
-            mask.style.backgroundColor = 'rgba(0,0,0,0.85)';
-            modal.style.transform = 'scale(1)'; modal.style.opacity = '1';
-            onTransitionEndOnce(modal, function () { animatingIn = false; actions.style.pointerEvents = ''; }, IN_DURATION + 80);
-          });
-        }
-      }
-
-      // 出场（反向动画）
-      function animateOut(after) {
-        if (closing || animatingIn) return;
-        closing = true; actions.style.pointerEvents = 'none';
-        var fromBg = getComputedStyle(mask).backgroundColor || 'rgba(0,0,0,0.85)';
-        if (supportsWAAPI) {
-          var maskOut = mask.animate(
-            [{ backgroundColor: fromBg }, { backgroundColor: 'rgba(0,0,0,0)' }],
-            { duration: OUT_DURATION, easing: 'ease', fill: 'forwards' }
-          );
-          var boxOut = modal.animate(
-            [{ transform: 'scale(1)', opacity: 1 }, { transform: 'scale(' + SCALE_FROM + ')', opacity: 0 }],
-            { duration: OUT_DURATION, easing: EASE_BOX, fill: 'forwards' }
-          );
-          Promise.all([finished(maskOut, OUT_DURATION + 80), finished(boxOut, OUT_DURATION + 80)]).then(function () {
-
-  // Disabled legacy guard in favor of final guard
-  if (window.__bnUseFinalGuard) { return; }
-            cleanup(); if (typeof after === 'function') try { after(); } catch (e) { }
-          });
-        } else {
-          modal.style.transition = 'transform ' + OUT_DURATION + 'ms ' + EASE_BOX + ', opacity ' + OUT_DURATION + 'ms ease';
-          mask.style.transition = 'background-color ' + OUT_DURATION + 'ms ease';
-          mask.style.backgroundColor = 'rgba(0,0,0,0)';
-          modal.style.transform = 'scale(' + SCALE_FROM + ')'; modal.style.opacity = '0';
-          onTransitionEndOnce(modal, function () { cleanup(); if (typeof after === 'function') try { after(); } catch (e) { }; }, OUT_DURATION + 80);
-        }
-      }
-
-      // 点击遮罩空白 => 反向动画
-      mask.addEventListener('click', function (e) { if (e.target === mask) animateOut(); }, { once: true });
-
-      // 外部 API（保持兼容）
-      mask.bnConfirm = function (onYesOrHref) {
-        if (typeof onYesOrHref === 'function') {
-          window.__bnConfirmCb = onYesOrHref;
-          if (mask.dataset) delete mask.dataset.bnHref;
-        } else if (typeof onYesOrHref === 'string') {
-          if (mask.dataset) mask.dataset.bnHref = onYesOrHref;
-          window.__bnConfirmCb = null;
-        }
-        // 确认：立即关闭并跳转/回调
-        ok.onclick = function (ev) {
-          ev.preventDefault(); ev.stopPropagation();
-          cleanup();
-          var href = (mask.dataset && mask.dataset.bnHref) || window.__bnPendingHref || ok.getAttribute('href');
-          if (typeof window.__bnConfirmCb === 'function') { try { window.__bnConfirmCb(); } catch (e) { } }
-          else if (href) { location.assign(href); }
-        };
-        // 取消：反向动画
-        cancel.onclick = function (ev) {
-          ev.preventDefault();
-          ev.stopPropagation();
-          if (ev.stopImmediatePropagation) ev.stopImmediatePropagation(); // 双保险
-          animateOut();
-        };
-
-      };
-
-      // 兜底
-      mask.bnAnimateOut = function () { animateOut(); };
-
-      animateIn();
-      return mask;
-    }
-    async function needWarn(problemId) {
-      try {
-        const r = await gmFetch({
-          url: CFG.base + `/problem/${problemId}`,
-          headers: { 'X-Requested-With': 'XMLHttpRequest' }
-        });
-        const html = r.responseText || '';
-        // 题目页上“提交记录/统计”按钮带有 check-need-button 时，代表未通过（element1.txt）
-        return /class="[^"]*check-need-button[^"]*"\s+data-href="\/submissions\?problem_id=\d+"/.test(html)
-          || /class="[^"]*check-need-button[^"]*"\s+data-href="\/problem\/\d+\/statistics/.test(html);
-      } catch { return false; }
-    }
-
-    function extractProblemIdFromRow(row) {
-      const a = $('a[href^="/problem/"]', row);
-      const m = a && a.getAttribute('href').match(/\/problem\/(\d+)/);
-      return m ? m[1] : null;
-    }
-
-
-    function extractSubmitterIdFromRow(row) {
-      const a = $('a[href^="/user/"]', row);
-      const m = a && a.getAttribute('href').match(/\/user\/(\d+)/);
-      return m ? m[1] : null;
-    }
-    // 事件委托，拦截点击 /submission/{id}
-    document.addEventListener('click', async (e) => {
-      const a = e.target && (e.target.closest && e.target.closest('a[href^="/submission/"]'));
-      if (!a) return;
-      // 仅左键 & 非修饰键
-      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-
-      const tr = a.closest('tr');
-      const pid = tr && extractProblemIdFromRow(tr);
-      if (!pid) return; // 找不到题号就放行
-      e.preventDefault(); e.stopPropagation(); e.stopImmediatePropagation();
-      const warn = await (window.needWarn ? window.needWarn(pid) : needWarn(pid));
-      if (!warn) {
-        location.href = a.href;
-        return;
-      }
-      const mask = ensureModal();
-      mask.bnConfirm(() => { location.href = a.href; });
-    }, true);
-
-  } catch (err) {
-    console.warn('[7fa4-better] submissions-guard error:', err);
+  function toKey(pid) {
+    if (pid === undefined || pid === null) return '';
+    return String(pid).trim();
   }
-})();
 
-
-(function () {
-  // Enable guard on /submissions and /problem/*/statistics/* pages
-  var __bn_path = location.pathname || '';
-  var __bn_onSubmissions = __bn_path.indexOf('/submissions') === 0;
-  var __bn_onProblemStats = /^\/problem\/[^\/]+\/statistics(\/|$)/.test(__bn_path);
-  if (!(__bn_onSubmissions || __bn_onProblemStats)) return;
-  if (window.__bnGlobalBound) return;
-  window.__bnGlobalBound = true;
-
-  // 捕获最近点击的“提交记录”链接，作为确认时的兜底跳转目标
-  document.addEventListener('click', function (e) {
-    const a = e.target && e.target.closest && e.target.closest('a[href^="/submission/"]');
-    if (a) {
-      window.__bnPendingHref = a.href;
+  function getCached(pid) {
+    const key = toKey(pid);
+    if (!key) return undefined;
+    const hit = solveCache.get(key);
+    if (!hit) return undefined;
+    if (hit.expires <= Date.now()) {
+      solveCache.delete(key);
+      return undefined;
     }
-  }, true);
+    return hit.value;
+  }
 
-  // 保险：万一按钮监听丢失，用事件委托兜底
-  document.addEventListener('click', function (e) {
-    const okBtn = e.target && e.target.closest && e.target.closest('#bn-guard-box .ui.red.ok.inverted.button');
-    if (okBtn) {
-      e.preventDefault(); e.stopPropagation();
-      const mask = document.getElementById('bn-guard-mask');
-      if (mask) {
-        const href = (mask.dataset && mask.dataset.bnHref) || window.__bnPendingHref || okBtn.getAttribute('href');
-        try { mask.remove(); } catch { }
-        try { document.body.classList.remove('dimmed'); } catch { }
-        if (typeof window.__bnConfirmCb === 'function') {
-          try { window.__bnConfirmCb(); } catch { }
-        } else if (href) {
-          location.assign(href);
-        }
-      }
+  function setCached(pid, value, ttl = TTL_MS) {
+    const key = toKey(pid);
+    if (!key) return;
+    solveCache.set(key, { value, expires: Date.now() + ttl });
+  }
+
+  function clearSolveCache() {
+    solveCache.clear();
+  }
+
+  function linkAbortSignals(controller, signal) {
+    if (!signal) return;
+    if (signal.aborted) {
+      try { controller.abort(signal.reason); } catch (_) { controller.abort(); }
       return;
     }
-    const cancelBtn = e.target && e.target.closest && e.target.closest('#bn-guard-box .ui.green.ok.inverted.button');
-    if (cancelBtn) {
-      e.preventDefault(); e.stopPropagation();
-      const mask = document.getElementById('bn-guard-mask');
-      if (mask) {
-        try { mask.remove(); } catch { }
-        try { document.body.classList.remove('dimmed'); } catch { }
-        delete window.__bnConfirmCb;
-        if (mask.dataset) delete mask.dataset.bnHref;
-      }
-    }
-  }, true);
-})();
-
-/* ===== SAFE PATCH: only warn when NOT passed (append-only) ===== */
-(function () {
-  const BASE = (window.CFG && window.CFG.base) ? window.CFG.base : '';
-
-  // 兼容 gmFetch；没有就用 fetch 简实现
-  const gmf = (typeof window.gmFetch === 'function')
-    ? window.gmFetch
-    : function (opt) {
-      return fetch(opt.url, { headers: opt.headers || {} })
-        .then(r => r.text())
-        .then(t => ({ responseText: t }));
+    const abort = () => {
+      try { controller.abort(signal.reason); }
+      catch (_) { controller.abort(); }
     };
-
-  async function hasAccepted(problemId) {
-    const uid = getCurrentUserId();
-    if (!uid) return false;
-    try {
-      const url = `${BASE}/submissions?problem_id=${problemId}&submitter=${uid}&min_score=100&max_score=100&language=&status=`;
-      const r = await gmf({ url, headers: { 'X-Requested-With': 'XMLHttpRequest' } });
-      const html = r && (r.responseText || r) || '';
-      return /class="[^"]*\bstatus\b[^"]*\baccepted\b[^"]*"/i.test(html) || />\s*Accepted\s*</i.test(html);
-    } catch (e) {
-      return false;
-    }
+    signal.addEventListener('abort', abort, { once: true });
   }
 
-  // 仅对“未通过”的题目弹窗：已通过 → false；否则兜底看题目页是否仍有 check-need-button
-  window.needWarn = async function (problemId) {
-    try {
-      if (await hasAccepted(problemId)) return false;
-    } catch (e) { /* ignore */ }
-
-    try {
-      const r = await gmf({ url: `${BASE}/problem/${problemId}`, headers: { 'X-Requested-With': 'XMLHttpRequest' } });
-      const html = r && (r.responseText || r) || '';
-      return /class="[^"]*check-need-button[^"]*"\s+data-href="\/submissions\?problem_id=\d+"/.test(html)
-        || /class="[^"]*check-need-button[^"]*"\s+data-href="\/problem\/\d+\/statistics/.test(html);
-    } catch (e) {
-      return false; // 失败则不弹，避免误伤
+  async function checkMyHundredSubmission(problemId, signal) {
+    const key = toKey(problemId);
+    if (!key) return false;
+    const url = `/api/submissions?me=1&score=100&problemId=${encodeURIComponent(key)}&limit=1`;
+    const resp = await fetch(url, { credentials: 'include', signal });
+    if (!resp.ok) {
+      throw new Error(`HTTP ${resp.status}`);
     }
-  };
-})();
-
-
-/* ===== FINAL PATCH: needWarn uses itemList + userId to guard only when NOT passed ===== */
-(function () {
-  const BASE = (window.CFG && window.CFG.base) ? window.CFG.base : '';
-
-  function sameOrigin(url) {
-    try { return new URL(url, location.origin).origin === location.origin; } catch { return false; }
-  }
-  function safeFetch(url, headers) {
-    if (sameOrigin(url) || url.startsWith('/')) {
-      return fetch(url, { headers: headers || {}, credentials: 'include' })
-        .then(r => r.text()).then(t => ({ responseText: t }));
-    }
-    if (typeof GM_xmlhttpRequest === 'function') {
-      return new Promise((resolve, reject) => {
-        GM_xmlhttpRequest({
-          method: 'GET', url, headers: headers || {}, withCredentials: true,
-          onload: r => resolve({ responseText: r.responseText }),
-          onerror: reject, ontimeout: reject
-        });
-      });
-    }
-    return fetch(url, { headers: headers || {} }).then(r => r.text()).then(t => ({ responseText: t }));
+    const data = await resp.json();
+    const items = data && data.items;
+    return Array.isArray(items) && items.length > 0;
   }
 
-  function parseItemList(html) {
-    const m = html && html.match(/const\s+itemList\s*=\s*(\[[\s\S]*?\]);/);
-    if (!m) return null;
-    try { return JSON.parse(m[1]); } catch (e) {
-      try { return Function('"use strict";return (' + m[1] + ')')(); } catch { return null; }
+  async function probeAcceptedBadge(problemId, signal) {
+    const key = toKey(problemId);
+    if (!key) return false;
+    const url = `/problem/${encodeURIComponent(key)}`;
+    const resp = await fetch(url, {
+      credentials: 'include',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      signal,
+    });
+    if (!resp.ok) {
+      throw new Error(`HTTP ${resp.status}`);
     }
+    const html = await resp.text();
+    return /data-accepted\s*=\s*(?:"|')?true(?:"|')?/i.test(html)
+      || /已通过/.test(html)
+      || /\bAccepted\b/i.test(html);
   }
 
-  function seenMineAndAccepted(list, uid) {
-    let seenMine = false, hasAC = false;
-    for (const it of (Array.isArray(list) ? list : [])) {
-      const info = it && it.info;
-      const res = it && it.result;
-      if (!info || !res) continue;
-      if (Number(info.userId) !== Number(uid)) continue;
-      seenMine = true;
-      const score = typeof res.score === 'number' ? res.score : parseInt(res.score || 0, 10);
-      if ((res.result === 'Accepted') || (score === 100)) { hasAC = true; break; }
-    }
-    return { seenMine, hasAC };
-  }
+  async function hasSolved(problemId, opts = {}) {
+    const key = toKey(problemId);
+    if (!key) return false;
+    const force = !!opts.force;
+    const externalSignal = opts.signal;
 
-  function tableSeenMineAndAccepted(html, uid) {
-    const m = html && html.match(/<tbody>([\s\S]*?)<\/tbody>/i);
-    if (!m) return { seenMine: false, hasAC: false };
-    const tbody = m[1];
-    const rows = tbody.split(/<\/tr>/i);
-    let seenMine = false, hasAC = false;
-    for (const row of rows) {
-      if (row.indexOf('/user/' + uid) === -1) continue;
-      seenMine = true;
-      if (/\bstatus\b[^>]*\baccepted\b/i.test(row) || />\s*Accepted\s*</i.test(row)) { hasAC = true; break; }
-    }
-    return { seenMine, hasAC };
-  }
-
-  window.needWarn = async function (problemId) {
-    const uid = getCurrentUserId();
-
-    // 1) submissions 列表判断（首选）
-    try {
-      const r = await safeFetch(`${BASE}/submissions?problem_id=${encodeURIComponent(problemId)}`, { 'X-Requested-With': 'XMLHttpRequest' });
-      const html = r && (r.responseText || r) || '';
-
-      const list = parseItemList(html);
-      if (list && Number.isFinite(uid)) {
-        const { seenMine, hasAC } = seenMineAndAccepted(list, uid);
-        if (seenMine) return !hasAC; // 看到了我的提交：有 AC 不拦；否则拦
-        return true;                 // 没有任何我的提交：视为未通过 → 拦
+    if (!force) {
+      const cached = getCached(key);
+      if (cached !== undefined) return cached;
+      const current = inFlight.get(key);
+      if (current) {
+        linkAbortSignals(current.controller, externalSignal);
+        return current.promise;
       }
-      if (Number.isFinite(uid)) {
-        const { seenMine, hasAC } = tableSeenMineAndAccepted(html, uid);
-        if (seenMine) return !hasAC;
-        return true;
+    } else {
+      const inflight = inFlight.get(key);
+      if (inflight) {
+        try { inflight.controller.abort('force-refresh'); } catch (_) { inflight.controller.abort(); }
+        inFlight.delete(key);
       }
-    } catch (e) {
-      // 继续走兜底
     }
 
-    // 2) 题目页兜底（存在 check-need-button 通常代表未通过）
-    try {
-      const r2 = await safeFetch(`${BASE}/problem/${encodeURIComponent(problemId)}`, { 'X-Requested-With': 'XMLHttpRequest' });
-      const h2 = r2 && (r2.responseText || r2) || '';
-      if (/class="[^"]*check-need-button[^"]*"\s+data-href="\/submissions\?problem_id=\d+"/.test(h2)
-        || /class="[^"]*check-need-button[^"]*"\s+data-href="\/problem\/\d+\/statistics/.test(h2)) {
-        return true;
+    const controller = new AbortController();
+    linkAbortSignals(controller, externalSignal);
+
+    const promise = (async () => {
+      try {
+        const ok = await checkMyHundredSubmission(key, controller.signal);
+        setCached(key, ok);
+        return ok;
+      } catch (primaryError) {
+        if (primaryError && primaryError.name === 'AbortError') {
+          throw primaryError;
+        }
+        try {
+          const ok = await probeAcceptedBadge(key, controller.signal);
+          setCached(key, ok, FALLBACK_TTL_MS);
+          return ok;
+        } catch (fallbackError) {
+          if (fallbackError && fallbackError.name === 'AbortError') {
+            throw fallbackError;
+          }
+          return false;
+        }
       }
-      return false;
-    } catch (e) {
-      // 3) 最后兜底：保守拦，避免“全不拦”
+    })().finally(() => {
+      inFlight.delete(key);
+    });
+
+    inFlight.set(key, { promise, controller });
+    return promise;
+  }
+
+  async function needWarn(problemId, opts = {}) {
+    try {
+      const solved = await hasSolved(problemId, opts);
+      return !solved;
+    } catch (err) {
+      if (err && err.name === 'AbortError') {
+        throw err;
+      }
       return true;
     }
-  };
-})();
-/* === Patch: global needWarn (only guard when NOT passed) === */
-(function () {
-  try {
-    if (window.__bnNeedWarnShimAdded) return; window.__bnNeedWarnShimAdded = true;
-    const BASE = (window.CFG && window.CFG.base) ? window.CFG.base : location.origin;
-    const gmf = (typeof window.gmFetch === 'function')
-      ? window.gmFetch
-      : (opt) => fetch(opt.url, { headers: opt.headers || {}, credentials: 'include' })
-        .then(r => r.text()).then(t => ({ responseText: t }));
+  }
 
-    async function hasAccepted(problemId) {
-      const uid = getCurrentUserId();
-      if (!uid) return false;
-      try {
-        const url = `${BASE}/submissions?problem_id=${problemId}&submitter=${uid}&min_score=100&max_score=100&language=&status=`;
-        const r = await gmf({ url, headers: { 'X-Requested-With': 'XMLHttpRequest' } });
-        const html = r && (r.responseText || r) || '';
-        return /class="[^"]*\bstatus\b[^"]*\baccepted\b[^"]*"/i.test(html) || />\s*Accepted\s*</i.test(html);
-      } catch (e) { return False; }
+  function extractProblemIdFromUrl(rawUrl) {
+    if (!rawUrl) return null;
+    try {
+      const url = new URL(rawUrl, global.location ? global.location.href : undefined);
+      const direct = url.pathname.match(/\/problem\/(\d+)/);
+      if (direct) return direct[1];
+      const qp = url.searchParams.get('problem_id') || url.searchParams.get('problemId');
+      if (qp) return qp;
+    } catch (_) { /* ignore */ }
+    return null;
+  }
+
+  function extractProblemIdFromLocation() {
+    if (!global.location) return null;
+    const pathId = (global.location.pathname && global.location.pathname.match(/\/problem\/(\d+)/));
+    if (pathId) return pathId[1];
+    try {
+      const url = new URL(global.location.href);
+      return url.searchParams.get('problem_id') || url.searchParams.get('problemId');
+    } catch (_) {
+      return null;
     }
+  }
 
-    if (typeof window.needWarn !== 'function') {
-      window.needWarn = async function (problemId) {
-        try { if (await hasAccepted(problemId)) return false; } catch (e) { }
-        try {
-          const r = await gmf({ url: `${BASE}/problem/${problemId}`, headers: { 'X-Requested-With': 'XMLHttpRequest' } });
-          const html = r && (r.responseText || r) || '';
-          return /class="[^"]*check-need-button[^"]*"\s+data-href="\/submissions\?problem_id=\d+"/.test(html)
-            || /class="[^"]*check-need-button[^"]*"\s+data-href="\/problem\/\d+\/statistics/.test(html);
-        } catch (e) { return false; }
-      };
-    }
-  } catch (_e) { }
-})();
-/* === 7fa4 Better | Submission Guard (final) === */
-(function () {
-  try {
-    if (window.__bnGuardFinalBound) return;
-    window.__bnGuardFinalBound = true;
+  function inferProblemId(anchor) {
+    if (!anchor) return extractProblemIdFromLocation();
+    const attrHref = anchor.getAttribute ? anchor.getAttribute('href') : anchor.href;
+    const direct = extractProblemIdFromUrl(attrHref || anchor.href);
+    if (direct) return direct;
 
-    function qs(sel, root) { return (root || document).querySelector(sel); }
-    function qsa(sel, root) { return Array.from((root || document).querySelectorAll(sel)); }
-    function sameOrigin(u) { try { return new URL(u, location.origin).origin === location.origin; } catch { return true; } }
-    function fetchText(u, headers) {
-      if (sameOrigin(u) || u.startsWith('/')) return fetch(u, { credentials: 'include', headers: headers || {} }).then(r => r.text());
-      return fetch(u, { headers: headers || {} }).then(r => r.text());
-    }
-
-    function parseItemList(html) {
-      const m = html && html.match(/const\s+itemList\s*=\s*(\[[\s\S]*?\]);/);
-      if (!m) return null;
-      const raw = m[1];
-      try { return JSON.parse(raw); } catch (e) {
-        try { return Function('"use strict";return (' + raw + ')')(); } catch { return null; }
+    const tr = anchor.closest && anchor.closest('tr');
+    if (tr) {
+      const datasetId = (tr.dataset && (tr.dataset.problemId || tr.dataset.problem_id));
+      if (datasetId) return datasetId;
+      const dataAttr = tr.getAttribute && (tr.getAttribute('data-problem-id') || tr.getAttribute('data-problemId'));
+      if (dataAttr) return dataAttr;
+      const probLink = tr.querySelector && tr.querySelector('a[href*="/problem/"]');
+      if (probLink) {
+        const linkId = extractProblemIdFromUrl(probLink.getAttribute('href') || probLink.href);
+        if (linkId) return linkId;
       }
     }
-    function userAcceptedFromItemList(list, uid) {
-      if (!Array.isArray(list)) return { seen: false, ac: false };
-      let seen = false, ac = false;
-      for (const it of list) {
-        const info = (it && it.info) || {}; const res = (it && it.result) || {};
-        if (Number(info.userId) !== Number(uid)) continue;
-        seen = true;
-        const score = typeof res.score === 'number' ? res.score : parseInt(res.score || 0, 10);
-        if (res.result === 'Accepted' || score === 100) { ac = true; break; }
-      }
-      return { seen, ac };
-    }
-    function userAcceptedFromTable(html, uid) {
-      const m = html && html.match(/<tbody>([\s\S]*?)<\/tbody>/i);
-      if (!m) return { seen: false, ac: false };
-      let seen = false, ac = false;
-      const rows = m[1].split(/<\/tr>/i);
-      for (const row of rows) {
-        if (row.indexOf('/user/' + uid) === -1) continue;
-        seen = true;
-        if (/\bstatus\b[^>]*\baccepted\b/i.test(row) || />\s*Accepted\s*</i.test(row)) { ac = true; break; }
-      }
-      return { seen, ac };
-    }
 
-    async function needWarn(problemId) {
-      const uid = getCurrentUserId();
-      try {
-        const html = await fetchText(`/submissions?problem_id=${encodeURIComponent(problemId)}`, { 'X-Requested-With': 'XMLHttpRequest' });
-        if (Number.isFinite(uid)) {
-          const list = parseItemList(html);
-          if (list) {
-            const { seen, ac } = userAcceptedFromItemList(list, uid);
-            if (seen) return !ac; // seen & not AC => warn (true)
-          } else {
-            const { seen, ac } = userAcceptedFromTable(html, uid);
-            if (seen) return !ac;
-          }
-        }
-      } catch (e) {/* ignore */ }
-      // fallback: look for check-need-button on problem page – existence means NOT passed
-      try {
-        const ph = await fetchText(`/problem/${encodeURIComponent(problemId)}`, { 'X-Requested-With': 'XMLHttpRequest' });
-        if (/class="[^"]*check-need-button[^"]*"\s+data-href="\/submissions\?problem_id=\d+"/.test(ph)
-          || /class="[^"]*check-need-button[^"]*"\s+data-href="\/problem\/\d+\/statistics/.test(ph)) {
-          return true;
-        }
-      } catch (e) { }
-      return false; // default allow
-    }
-    window.needWarn = needWarn; // expose
+    return extractProblemIdFromLocation();
+  }
 
-    function ensureSimpleModal() {
-      var IN_DURATION = 420;
-      var OUT_DURATION = 420;
-      var EASE_BOX = 'cubic-bezier(.2,.8,.2,1)';
-      var SCALE_FROM = 0.88;
+  function isGuardPage() {
+    if (!global.location) return false;
+    const path = global.location.pathname || '';
+    return path.indexOf('/submissions') === 0
+      || /^\/problem\/[^/]+\/statistics(\/|$)/.test(path);
+  }
 
-      // 强制全屏 & 居中，避免被站内样式拉到左上
-      if (!document.getElementById('bn-center-css')) {
-        var cs = document.createElement('style');
-        cs.id = 'bn-center-css';
-        cs.textContent = [
-          '#bn-guard-mask{position:fixed!important;inset:0!important;left:0!important;top:0!important;right:0!important;bottom:0!important;display:flex!important;align-items:center!important;justify-content:center!important;z-index:2147483647!important;pointer-events:auto!important;}',
-          '#bn-guard-box{position:static!important;top:auto!important;left:auto!important;margin:0!important;}'
-        ].join('\n');
-        document.head.appendChild(cs);
-      }
-
-      // 构建 DOM（保持站内结构/类名）
-      var mask = document.getElementById('bn-guard-mask');
-      if (!mask) {
-        mask = document.createElement('div');
-        mask.id = 'bn-guard-mask';
-        document.body.appendChild(mask);
-      }
-      mask.className = 'ui dimmer modals page transition visible active';
-      mask.style.display = 'flex';
-      try { document.body.classList.add('dimmed'); } catch (e) { }
-      mask.innerHTML = '';
-
-      var modal = document.createElement('div');
-      modal.id = 'bn-guard-box';
-      modal.className = 'ui basic modal check-need-modal transition visible active';
-      modal.style.position = 'static';
-      modal.style.margin = '0';
-
-      var header = document.createElement('div');
-      header.className = 'ui icon header';
-      var icon = document.createElement('i'); icon.className = 'exclamation triangle icon';
-      header.appendChild(icon);
-      header.appendChild(document.createTextNode('是否继续'));
-
-      var content = document.createElement('div');
-      content.className = 'content';
-      content.textContent = '未通过题目前查看他人答案将获得较低的评级，请经过深入思考以后，确实难以解决再选择查看。';
-
-      var actions = document.createElement('div');
-      actions.className = 'actions';
-      var ok = document.createElement('a'); ok.className = 'ui red ok inverted button'; ok.textContent = '确认';
-      // 关键：取消按钮不要含 ok/approve/deny，避免被 Semantic UI 接管
-      var cancel = document.createElement('button'); cancel.type = 'button';
-      cancel.className = 'ui green inverted button bn-cancel';
-      cancel.textContent = '取消';
-      actions.appendChild(ok); actions.appendChild(cancel);
-
-      modal.appendChild(header); modal.appendChild(content); modal.appendChild(actions);
-      mask.appendChild(modal);
-
-      // 捕获阶段阻断站内委托（只作用于本弹窗内部），避免立即关闭导致看不到动画
-      function captureBlocker(ev) {
-        // 只在我们这个弹窗内部拦截“无关点击”，放行确认和取消
-        if (modal.contains(ev.target)) {
-          // 放行确认按钮
-          if (ev.target === ok) return;
-          // 放行取消按钮（带 .bn-cancel 的元素或其子元素）
-          if (ev.target.closest && ev.target.closest('.bn-cancel')) return;
-
-          // 其它点击才拦截，避免被站内委托（Semantic UI）抢走
-          ev.preventDefault();
-          ev.stopPropagation();
-          ev.stopImmediatePropagation();
-        }
-      }
-
-      document.addEventListener('click', captureBlocker, true);
-
-      // 工具
-      var supportsWAAPI = typeof modal.animate === 'function';
-      var animatingIn = true;
-      var closing = false;
-      actions.style.pointerEvents = 'none';
-
-      function cleanup() {
-        try { document.removeEventListener('click', captureBlocker, true); } catch (e) { }
-        try { mask.remove(); } catch (e) { }
-        try { document.body.classList.remove('dimmed'); } catch (e) { }
-        if (mask.dataset) delete mask.dataset.bnHref;
-        delete window.__bnConfirmCb;
-      }
-      function onTransitionEndOnce(el, cb, timeout) {
-        var done = false;
-        function finish() { if (done) return; done = true; try { el.removeEventListener('transitionend', handler); } catch (e) { }; cb && cb(); }
-        function handler(ev) { if (ev && ev.target !== el) return; finish(); }
-        el.addEventListener('transitionend', handler);
-        setTimeout(finish, typeof timeout === 'number' ? timeout : 600);
-      }
-      function finished(anim, timeout) {
-        return new Promise(function (resolve) {
-          var done = false; function fin() { if (done) return; done = true; resolve(); }
-          if (anim && anim.finished && typeof anim.finished.then === 'function') anim.finished.then(fin).catch(fin);
-          else setTimeout(fin, timeout || 600);
-        });
-      }
-
-      // 入场
-      function animateIn() {
-        mask.style.backgroundColor = 'rgba(0,0,0,0)';
-        modal.style.transformOrigin = 'center center';
-        if (supportsWAAPI) {
-          var maskIn = mask.animate(
-            [{ backgroundColor: 'rgba(0,0,0,0)' }, { backgroundColor: 'rgba(0,0,0,0.85)' }],
-            { duration: IN_DURATION, easing: 'ease', fill: 'forwards' }
-          );
-          var boxIn = modal.animate(
-            [{ transform: 'scale(' + SCALE_FROM + ')', opacity: 0 }, { transform: 'scale(1)', opacity: 1 }],
-            { duration: IN_DURATION, easing: EASE_BOX, fill: 'forwards' }
-          );
-          Promise.all([finished(maskIn, IN_DURATION + 80), finished(boxIn, IN_DURATION + 80)]).then(function () {
-            animatingIn = false; actions.style.pointerEvents = '';
-          });
-        } else {
-          modal.style.transition = 'transform ' + IN_DURATION + 'ms ' + EASE_BOX + ', opacity ' + IN_DURATION + 'ms ease';
-          mask.style.transition = 'background-color ' + IN_DURATION + 'ms ease';
-          modal.style.transform = 'scale(' + SCALE_FROM + ')'; modal.style.opacity = '0';
-          void modal.offsetHeight;
-          requestAnimationFrame(function () {
-            mask.style.backgroundColor = 'rgba(0,0,0,0.85)';
-            modal.style.transform = 'scale(1)'; modal.style.opacity = '1';
-            onTransitionEndOnce(modal, function () { animatingIn = false; actions.style.pointerEvents = ''; }, IN_DURATION + 80);
-          });
-        }
-      }
-
-      // 出场（反向动画）
-      function animateOut(after) {
-        if (closing || animatingIn) return;
-        closing = true; actions.style.pointerEvents = 'none';
-        var fromBg = getComputedStyle(mask).backgroundColor || 'rgba(0,0,0,0.85)';
-        if (supportsWAAPI) {
-          var maskOut = mask.animate(
-            [{ backgroundColor: fromBg }, { backgroundColor: 'rgba(0,0,0,0)' }],
-            { duration: OUT_DURATION, easing: 'ease', fill: 'forwards' }
-          );
-          var boxOut = modal.animate(
-            [{ transform: 'scale(1)', opacity: 1 }, { transform: 'scale(' + SCALE_FROM + ')', opacity: 0 }],
-            { duration: OUT_DURATION, easing: EASE_BOX, fill: 'forwards' }
-          );
-          Promise.all([finished(maskOut, OUT_DURATION + 80), finished(boxOut, OUT_DURATION + 80)]).then(function () {
-
-  // Disabled legacy guard in favor of final guard
-  if (window.__bnUseFinalGuard) { return; }
-            cleanup(); if (typeof after === 'function') try { after(); } catch (e) { }
-          });
-        } else {
-          modal.style.transition = 'transform ' + OUT_DURATION + 'ms ' + EASE_BOX + ', opacity ' + OUT_DURATION + 'ms ease';
-          mask.style.transition = 'background-color ' + OUT_DURATION + 'ms ease';
-          mask.style.backgroundColor = 'rgba(0,0,0,0)';
-          modal.style.transform = 'scale(' + SCALE_FROM + ')'; modal.style.opacity = '0';
-          onTransitionEndOnce(modal, function () { cleanup(); if (typeof after === 'function') try { after(); } catch (e) { }; }, OUT_DURATION + 80);
-        }
-      }
-
-      // 点击遮罩空白 => 反向动画
-      mask.addEventListener('click', function (e) { if (e.target === mask) animateOut(); }, { once: true });
-
-      // 外部 API（保持兼容）
-      mask.bnConfirm = function (onYesOrHref) {
-        if (typeof onYesOrHref === 'function') {
-          window.__bnConfirmCb = onYesOrHref;
-          if (mask.dataset) delete mask.dataset.bnHref;
-        } else if (typeof onYesOrHref === 'string') {
-          if (mask.dataset) mask.dataset.bnHref = onYesOrHref;
-          window.__bnConfirmCb = null;
-        }
-        // 确认：立即关闭并跳转/回调
-        ok.onclick = function (ev) {
-          ev.preventDefault(); ev.stopPropagation();
-          cleanup();
-          var href = (mask.dataset && mask.dataset.bnHref) || window.__bnPendingHref || ok.getAttribute('href');
-          if (typeof window.__bnConfirmCb === 'function') { try { window.__bnConfirmCb(); } catch (e) { } }
-          else if (href) { location.assign(href); }
-        };
-        // 取消：反向动画
-        cancel.onclick = function (ev) {
-          ev.preventDefault();
-          ev.stopPropagation();
-          if (ev.stopImmediatePropagation) ev.stopImmediatePropagation(); // 双保险
-          animateOut();
-        };
-
-      };
-
-      // 兜底
-      mask.bnAnimateOut = function () { animateOut(); };
-
-      animateIn();
-      return mask;
-    }
-
-    function getPidFromRow(tr) {
-      const a = tr && tr.querySelector('td:nth-child(2) a[href^="/problem/"]');
-      if (!a) return null;
-      const m = a.getAttribute('href').match(/\/problem\/(\d+)/);
-      return m ? m[1] : null;
-    }
-
-    // Capture-phase click interception for /submission/{id}
-    document.addEventListener('click', async function (e) {
-      const a = e.target && (e.target.closest && e.target.closest('a[href^="/submission/"]'));
-      if (!a) return;
-      if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
-
-      const tr = a.closest('tr');
-      const pid = getPidFromRow(tr);
-      if (!pid) return; // unknown problem -> let it go
-
-      e.preventDefault();
-      try {
-        const warn = await needWarn(pid); // true => 未通过，需要弹窗
-        if (!warn) {
-          location.href = a.href;
-          return;
-        }
-      } catch (_) { /* on error, fall through to warn */ }
-
-      const mask = (typeof window.ensureModal === 'function' ? ensureModal() : ensureSimpleModal());
-      if (mask && typeof mask.bnConfirm === 'function') {
-        mask.bnConfirm(() => { location.href = a.href; });
-      }
-    }, true);
-  } catch (_e) { }
-})();
-/* === Patch: Submission Guard — scan *all* submissions (any AC across all pages) ===
- * 说明：这一补丁不删除原逻辑，只在文件末尾**覆写** window.needWarn：
- * - 先用带过滤条件的“提交记录”列表（submitter + score=100）直接判断是否存在任何 AC（跨页有效）；
- * - 若无法判定，再退回未过滤的提交记录页面，解析 itemList/table 看本页是否看到本人且是否有 AC；
- * - 仍无法判定，最后通过题目页上的 check-need-button 作为兜底（存在则拦）。
- * 结论：只要“所有提交中出现过一次 AC”（已通过），就不拦；否则就拦。
- */
-(function () {
-  try {
-    var BASE = (window.CFG && window.CFG.base) ? window.CFG.base : location.origin;
-
-    function sameOrigin(u) { try { return new URL(u, location.origin).origin === location.origin; } catch (e) { return false; } }
-    function fetchText(u, headers) {
-      var opt = { headers: headers || {} };
-      if (sameOrigin(u) || (typeof u === 'string' && u.indexOf('/') === 0)) opt.credentials = 'include';
-      return fetch(u, opt).then(function (r) { return r.text(); });
-    }
-
-    function parseItemList(html) {
-      var m = html && html.match(/const\s+itemList\s*=\s*(\[[\s\S]*?\]);/);
-      if (!m) return null;
-      var raw = m[1];
-      try { return JSON.parse(raw); }
-      catch (e) { try { return Function('"use strict";return (' + raw + ')')(); } catch (_e) { return null; } }
-    }
-
-    function userSeenAndAnyACFromList(list, uid) {
-      if (!Array.isArray(list)) return { seen: false, anyAC: false };
-      var seen = false, anyAC = false;
-      for (var i = 0; i < list.length; i++) {
-        var it = list[i] || {};
-        var info = it.info || {}, res = it.result || {};
-        if (Number(info.userId) !== Number(uid)) continue;
-        seen = true;
-        var score = typeof res.score === 'number' ? res.score : parseInt(res.score || 0, 10);
-        if (res.result === 'Accepted' || score === 100) { anyAC = true; break; }
-      }
-      return { seen: seen, anyAC: anyAC };
-    }
-
-    function userSeenAndAnyACFromTable(html, uid) {
-      var m = html && html.match(/<tbody>([\s\S]*?)<\/tbody>/i);
-      if (!m) return { seen: false, anyAC: false };
-      var seen = false, anyAC = false;
-      var rows = m[1].split(/<\/tr>/i);
-      for (var i = 0; i < rows.length; i++) {
-        var row = rows[i];
-        if (row.indexOf('/user/' + uid) === -1) continue;
-        seen = true;
-        if (/\bstatus\b[^>]*\baccepted\b/i.test(row) || />\s*Accepted\s*</i.test(row)) { anyAC = true; break; }
-      }
-      return { seen: seen, anyAC: anyAC };
-    }
-
-    async function hasAnyAcceptedAcrossAll(problemId) {
-      const uid = getCurrentUserId();
-      if (!uid) return null; // 无法识别登录用户
-
-      // 1) 首选：使用过滤后的“仅本人 + 成功(100 分)”列表，天然跨页
-      try {
-        var urlOk = BASE + '/submissions?problem_id=' + encodeURIComponent(problemId)
-          + '&submitter=' + encodeURIComponent(uid)
-          + '&min_score=100&max_score=100&language=&status=';
-        var hOk = await fetchText(urlOk, { 'X-Requested-With': 'XMLHttpRequest' });
-        var listOk = parseItemList(hOk);
-        if (listOk) {
-          var r1 = userSeenAndAnyACFromList(listOk, uid);
-          // 该过滤已限定“只看 100 分”，因此 seen=true 即视为存在 AC
-          if (r1.seen) return true;
-        } else {
-          // 直接字符串判断 “Accepted” 即可
-          if (/class="[^"]*\bstatus\b[^"]*\baccepted\b[^"]*"/i.test(hOk) || />\s*Accepted\s*</i.test(hOk)) return true;
-          // 若能看到本人但没看到 Accepted，保守返回 false（见到本人但没有 AC）
-          if (new RegExp('/user/' + uid).test(hOk)) return false;
-        }
-      } catch (e) { /* ignore */ }
-
-      // 2) 次选：不加过滤，解析 itemList/table —— 仅能看到“当前页”的本人提交
-      try {
-        var url = BASE + '/submissions?problem_id=' + encodeURIComponent(problemId);
-        var html = await fetchText(url, { 'X-Requested-With': 'XMLHttpRequest' });
-        var list = parseItemList(html);
-        if (list) {
-          var r2 = userSeenAndAnyACFromList(list, uid);
-          if (r2.seen) return r2.anyAC;
-        } else {
-          var r3 = userSeenAndAnyACFromTable(html, uid);
-          if (r3.seen) return r3.anyAC;
-        }
-      } catch (e) { /* ignore */ }
-
-      return null; // 仍无法判定，交给兜底
-    }
-
-    var WARN_CACHE_TTL = 5 * 60 * 1000; // 5 分钟缓存
-    var warnCache = new Map();
-
-    async function needWarnFallback(pid) {
-      try {
-        var ph = await fetchText(BASE + '/problem/' + encodeURIComponent(pid), { 'X-Requested-With': 'XMLHttpRequest' });
-        if (/class="[^"]*check-need-button[^"]*"\s+data-href="\/submissions\?problem_id=\d+"/.test(ph)
-          || /class="[^"]*check-need-button[^"]*"\s+data-href="\/problem\/\d+\/statistics/.test(ph)) {
-          return true;
-        }
-      } catch (e) { /* ignore */ }
+  function shouldGuardLink(anchor) {
+    if (!anchor) return false;
+    if (anchor.closest && anchor.closest('#bn-guard-box')) return false;
+    const href = anchor.getAttribute ? anchor.getAttribute('href') : anchor.href;
+    if (!href || /^javascript:/i.test(href)) return false;
+    try {
+      const url = new URL(href, global.location ? global.location.href : undefined);
+      if (global.location && url.origin !== global.location.origin) return false;
+      if (anchor.target && anchor.target.toLowerCase() === '_blank') return false;
+      return /^\/submission\//.test(url.pathname || '');
+    } catch (_) {
       return false;
     }
+  }
 
-    // 覆写 needWarn：有 AC => 不拦；无 AC => 拦；无法判定 => 兜底看题目页
-    window.needWarn = async function (problemId, opt) {
-      var force = opt && opt.force;
-      var now = Date.now();
-      var hit = warnCache.get(problemId);
-      if (!force && hit && now - hit.time < WARN_CACHE_TTL) return hit.value;
+  function showGuardConfirm(onConfirm, onCancel) {
+    try {
+      if (global.mask && typeof global.mask.bnConfirm === 'function') {
+        global.mask.bnConfirm(onConfirm);
+        return;
+      }
+    } catch (_) { /* ignore */ }
+    try {
+      const ensure = global.ensureModal || global.ensureSimpleModal;
+      if (typeof ensure === 'function') {
+        const mask = ensure();
+        if (mask && typeof mask.bnConfirm === 'function') {
+          mask.bnConfirm(onConfirm);
+          return;
+        }
+      }
+    } catch (_) { /* ignore */ }
+    const message = '未通过题目前查看他人答案将获得较低的评级，请经过深入思考以后，确实难以解决再选择查看。';
+    if (global.confirm ? global.confirm(message) : true) {
+      onConfirm();
+    } else if (typeof onCancel === 'function') {
+      onCancel();
+    }
+  }
 
-      var warn;
-      try {
-        var passed = await hasAnyAcceptedAcrossAll(problemId);
-        if (passed === true) warn = false;
-        else if (passed === false) warn = true;
-      } catch (e) { /* ignore */ }
-      if (warn === undefined) warn = await needWarnFallback(problemId);
-      warnCache.set(problemId, { value: warn, time: now });
-      return warn;
-    };
-    window.needWarn.clearCache = function () { warnCache.clear(); };
-  } catch (_e) { /* ignore */ }
-})();
+  let activeController = null;
+  let lastNavigationHref = null;
+
+  function abortActive(reason) {
+    if (!activeController) return;
+    try { activeController.abort(reason); } catch (_) { activeController.abort(); }
+    activeController = null;
+  }
+
+  function navigateTo(href) {
+    lastNavigationHref = href;
+    if (global.location && typeof global.location.assign === 'function') {
+      global.location.assign(href);
+    }
+  }
+
+  function handleGuardNavigation(anchor) {
+    const problemId = inferProblemId(anchor);
+    if (!problemId) {
+      navigateTo(anchor.href);
+      return;
+    }
+
+    abortActive();
+    const controller = new AbortController();
+    activeController = controller;
+
+    needWarn(problemId, { signal: controller.signal }).then((warn) => {
+      if (controller.signal.aborted) return;
+      activeController = null;
+      if (!warn) {
+        navigateTo(anchor.href);
+        return;
+      }
+      showGuardConfirm(() => {
+        abortActive();
+        navigateTo(anchor.href);
+      });
+    }).catch((err) => {
+      if (controller.signal.aborted) return;
+      activeController = null;
+      if (err && err.name === 'AbortError') return;
+      showGuardConfirm(() => {
+        abortActive();
+        navigateTo(anchor.href);
+      });
+    });
+  }
+
+  function onDocumentClick(event) {
+    if (!event || event.defaultPrevented) return;
+    if (event.button !== undefined && event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+    const anchor = event.target && (event.target.closest ? event.target.closest('a[href]') : null);
+    if (!anchor || !shouldGuardLink(anchor)) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    handleGuardNavigation(anchor);
+  }
+
+  function installGuard() {
+    if (!isGuardPage()) return;
+    if (global.__bnUnifiedGuardInstalled) return;
+    if (!global.document || typeof global.document.addEventListener !== 'function') return;
+    global.__bnUnifiedGuardInstalled = true;
+    global.document.addEventListener('click', onDocumentClick, true);
+    if (typeof global.addEventListener === 'function') {
+      const cleanup = () => abortActive('pagehide');
+      global.addEventListener('pagehide', cleanup);
+      global.addEventListener('popstate', cleanup);
+    }
+  }
+
+  const api = {
+    TTL_MS,
+    FALLBACK_TTL_MS,
+    hasSolved,
+    needWarn,
+    clearSolveCache,
+    solveCache,
+    inFlight,
+    installGuard,
+    abortActive,
+    get lastNavigation() { return lastNavigationHref; },
+  };
+
+  global.__bnUnifiedGuard = api;
+  global.hasSolved = hasSolved;
+  global.needWarn = needWarn;
+  global.hasSolvedCache = { clear: clearSolveCache };
+  hasSolved.clearCache = clearSolveCache;
+  needWarn.clearCache = clearSolveCache;
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  installGuard();
+})(typeof window !== 'undefined' ? window : (typeof globalThis !== 'undefined' ? globalThis : this));
 
 /* === BN PATCH: user menu animation + shadow === */
 (function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,695 @@
+{
+  "name": "better-names-for-7fa4",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "better-names-for-7fa4",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "jsdom": "^27.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.0.5.tgz",
+      "integrity": "sha512-lMrXidNhPGsDjytDy11Vwlb6OIGrT3CmLg3VWNFyWkLWtijKl7xjvForlh8vuj0SHGjgl4qZEQzUmYTeQA2JFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.1"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.5.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.5.6.tgz",
+      "integrity": "sha512-Mj3Hu9ymlsERd7WOsUKNUZnJYL4IZ/I9wVVYgtvOsWYiEFbkQ4G7VRIh2USxTVW4BBDIsLG+gBUgqOqf2Kvqow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.1"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.14.tgz",
+      "integrity": "sha512-zSlIxa20WvMojjpCSy8WrNpcZ61RqfTfX3XTaOeVlGJrt/8HF3YbzgFZa01yTbT4GWQLwfTcC3EB8i3XnB647Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.1.tgz",
+      "integrity": "sha512-g5PC9Aiph9eiczFpcgUhd9S4UUO3F+LHGRIi5NUMZ+4xtoIYbHNZwZnWA2JsFGe8OU8nl4WyaEFiZuGuxlutJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.0.3",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.14",
+        "css-tree": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.0.tgz",
+      "integrity": "sha512-lIHeR1qlIRrIN5VMccd8tI2Sgw6ieYXSVktcSHaNe3Z5nE/tcPQYQWOq00wxMvYOsz+73eAkNenVvmPC6bba9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.5.4",
+        "cssstyle": "^5.3.0",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^7.3.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0",
+        "ws": "^8.18.2",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
+      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tldts": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.16.tgz",
+      "integrity": "sha512-5bdPHSwbKTeHmXrgecID4Ljff8rQjv7g8zKQPkCozRo2HWWni+p310FSn5ImI+9kWw9kK4lzOB5q/a6iv0IJsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.16"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.16",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.16.tgz",
+      "integrity": "sha512-XHhPmHxphLi+LGbH0G/O7dmUH9V65OY20R7vH8gETHsp5AZCjBk9l8sqmRKLaGOxnETU7XNSDUPtewAy/K6jbA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.0.tgz",
+      "integrity": "sha512-n4W4YFyz5JzOfQeA8oN7dUYpR+MBP3PIUsn2jLjWXwK5ASUzt0Jc/A5sAUZoCYFJRGF0FBKJ+1JjN43rNdsQzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "better-names-for-7fa4",
+  "version": "1.0.0",
+  "description": "本仓库提供一个适用于 7FA4 在线评测系统的 Tampermonkey 用户脚本，旨在改进界面显示并提供便捷功能。",
+  "main": "main.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jsdom": "^27.0.0"
+  }
+}

--- a/tests/helpers/load-guard.js
+++ b/tests/helpers/load-guard.js
@@ -1,0 +1,74 @@
+const { readFileSync } = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const source = readFileSync(path.resolve(__dirname, '../../main.js'), 'utf8');
+const startMarker = '/* === Unified Submission Guard (self+100pt single source) === */';
+const endMarker = '/* === BN PATCH: user menu animation + shadow === */';
+const start = source.indexOf(startMarker);
+const end = source.indexOf(endMarker);
+if (start === -1 || end === -1) {
+  throw new Error('Unable to locate unified guard source block in main.js');
+}
+const guardSource = source.slice(start, end);
+
+function makeLocation(url) {
+  const base = new URL(url || 'http://example.com/');
+  const loc = {
+    href: base.href,
+    origin: base.origin,
+    protocol: base.protocol,
+    host: base.host,
+    hostname: base.hostname,
+    port: base.port,
+    pathname: base.pathname,
+    search: base.search,
+    hash: base.hash,
+    assign(nextHref) {
+      const resolved = new URL(nextHref, this.href);
+      this.href = resolved.href;
+      this.origin = resolved.origin;
+      this.protocol = resolved.protocol;
+      this.host = resolved.host;
+      this.hostname = resolved.hostname;
+      this.port = resolved.port;
+      this.pathname = resolved.pathname;
+      this.search = resolved.search;
+      this.hash = resolved.hash;
+      this.lastAssigned = resolved.href;
+    },
+    toString() { return this.href; },
+  };
+  return loc;
+}
+
+function loadGuardModule({ context, overrides } = {}) {
+  const ctx = context || vm.createContext({});
+  const globalLike = ctx;
+  if (!('globalThis' in globalLike)) globalLike.globalThis = globalLike;
+  if (!('window' in globalLike)) globalLike.window = globalLike;
+  if (!('self' in globalLike)) globalLike.self = globalLike;
+  if (!('console' in globalLike)) globalLike.console = console;
+  if (!('AbortController' in globalLike)) globalLike.AbortController = globalThis.AbortController;
+  if (!('setTimeout' in globalLike)) globalLike.setTimeout = setTimeout;
+  if (!('clearTimeout' in globalLike)) globalLike.clearTimeout = clearTimeout;
+  if (!('URL' in globalLike)) globalLike.URL = URL;
+  if (!('URLSearchParams' in globalLike)) globalLike.URLSearchParams = URLSearchParams;
+  if (!('Promise' in globalLike)) globalLike.Promise = Promise;
+  if (!('Map' in globalLike)) globalLike.Map = Map;
+  if (!('location' in globalLike)) {
+    globalLike.location = makeLocation();
+  }
+  if (overrides && typeof overrides === 'object') {
+    Object.assign(globalLike, overrides);
+  }
+
+  vm.runInContext(guardSource, ctx);
+  return { context: ctx, guard: globalLike.__bnUnifiedGuard };
+}
+
+module.exports = {
+  loadGuardModule,
+  makeLocation,
+  guardSource,
+};

--- a/tests/solve-status.test.js
+++ b/tests/solve-status.test.js
@@ -1,0 +1,236 @@
+const { test, beforeEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { JSDOM } = require('jsdom');
+const { loadGuardModule, makeLocation } = require('./helpers/load-guard');
+
+function delay(ms = 0) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test('hasSolved uses 100pt submissions as truth source', async () => {
+  const calls = [];
+  const fetchStub = async (url) => {
+    calls.push(url);
+    if (url.startsWith('/api/submissions')) {
+      return {
+        ok: true,
+        json: async () => ({ items: [{}] }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const { guard } = loadGuardModule({
+    overrides: {
+      fetch: fetchStub,
+      location: makeLocation('http://example.com/'),
+    },
+  });
+  assert.equal(await guard.hasSolved('123'), true);
+  assert.equal(await guard.needWarn('123'), false);
+  assert.equal(calls.length, 1);
+});
+
+test('needWarn returns true when no accepted submission exists', async () => {
+  let calls = 0;
+  const fetchStub = async (url) => {
+    calls += 1;
+    if (url.startsWith('/api/submissions')) {
+      return {
+        ok: true,
+        json: async () => ({ items: [] }),
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const { guard } = loadGuardModule({
+    overrides: {
+      fetch: fetchStub,
+      location: makeLocation('http://example.com/submissions'),
+    },
+  });
+  assert.equal(await guard.hasSolved('456'), false);
+  assert.equal(await guard.needWarn('456'), true);
+  assert.equal(calls, 1);
+});
+
+test('fallback accepted badge caches with shorter TTL', async () => {
+  let now = 1700000000000;
+  const FakeDate = class extends Date {
+    static now() {
+      return now;
+    }
+  };
+  const fetchStub = async (url) => {
+    if (url.startsWith('/api/submissions')) {
+      throw new Error('primary failure');
+    }
+    if (url.startsWith('/problem/')) {
+      return {
+        ok: true,
+        text: async () => '<div data-accepted="true">Accepted</div>',
+      };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  const { guard, context } = loadGuardModule({
+    overrides: {
+      fetch: fetchStub,
+      Date: FakeDate,
+      location: makeLocation('http://example.com/problem/42/statistics'),
+    },
+  });
+  assert.equal(await guard.hasSolved('789'), true);
+  assert.equal(await guard.needWarn('789'), false);
+  const cacheEntry = context.__bnUnifiedGuard.solveCache.get('789');
+  assert.ok(cacheEntry, 'cache entry missing');
+  assert.equal(cacheEntry.expires, now + guard.FALLBACK_TTL_MS);
+});
+
+test('caching dedupes requests and obeys TTL/force', async () => {
+  let now = 0;
+  const FakeDate = class extends Date {
+    static now() {
+      return now;
+    }
+  };
+  let calls = 0;
+  const fetchStub = async (url) => {
+    if (!url.startsWith('/api/submissions')) {
+      throw new Error(`unexpected fetch: ${url}`);
+    }
+    calls += 1;
+    return {
+      ok: true,
+      json: async () => ({ items: [{}] }),
+    };
+  };
+  const { guard, context } = loadGuardModule({
+    overrides: {
+      fetch: fetchStub,
+      Date: FakeDate,
+      location: makeLocation('http://example.com/'),
+    },
+  });
+  const results = await Promise.all([
+    guard.hasSolved('p1'),
+    guard.hasSolved('p1'),
+    guard.hasSolved('p1'),
+  ]);
+  assert.deepEqual(results, [true, true, true]);
+  assert.equal(calls, 1);
+
+  now += guard.TTL_MS - 1000;
+  assert.equal(await guard.hasSolved('p1'), true);
+  assert.equal(calls, 1);
+
+  now += 2000;
+  assert.equal(await guard.hasSolved('p1'), true);
+  assert.equal(calls, 2);
+
+  await guard.hasSolved('p1', { force: true });
+  assert.equal(calls, 3);
+
+  guard.clearSolveCache();
+  assert.equal(context.__bnUnifiedGuard.solveCache.size, 0);
+});
+
+test('needWarn treats failures as warning by default', async () => {
+  let calls = 0;
+  const fetchStub = async () => {
+    calls += 1;
+    throw new Error('network failure');
+  };
+  const { guard } = loadGuardModule({
+    overrides: {
+      fetch: fetchStub,
+      location: makeLocation('http://example.com/problem/11'),
+    },
+  });
+  assert.equal(await guard.hasSolved('11'), false);
+  assert.equal(await guard.needWarn('11'), true);
+  assert.equal(calls >= 2, true, 'should attempt both primary and fallback sources');
+});
+
+test('guard intercepts submission links and prompts when unsolved', async () => {
+  const dom = new JSDOM(`
+    <table>
+      <tr>
+        <td></td>
+        <td><a href="/problem/42">Problem 42</a></td>
+        <td><a id="sub" href="/submission/777">View</a></td>
+      </tr>
+    </table>
+    <a id="other" href="/problem/42">Other</a>
+  `, { url: 'http://example.com/submissions?problem_id=42', runScripts: 'outside-only' });
+
+  dom.window.fetch = async (url) => {
+    if (url.startsWith('/api/submissions')) {
+      return { ok: true, json: async () => ({ items: [] }) };
+    }
+    if (url.startsWith('/problem/')) {
+      return { ok: true, text: async () => '<div></div>' };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  let confirmCount = 0;
+  dom.window.confirm = () => { confirmCount += 1; return false; };
+  const { context } = loadGuardModule({
+    context: dom.getInternalVMContext(),
+    overrides: {
+      fetch: dom.window.fetch,
+      confirm: dom.window.confirm,
+    },
+  });
+
+  const other = dom.window.document.getElementById('other');
+  const otherEvent = new dom.window.MouseEvent('click', { bubbles: true, cancelable: true });
+  const otherResult = other.dispatchEvent(otherEvent);
+  assert.equal(otherResult, true, 'non-guarded link should not be intercepted');
+
+  const anchor = dom.window.document.getElementById('sub');
+  const originalHref = dom.window.location.href;
+  const event = new dom.window.MouseEvent('click', { bubbles: true, cancelable: true });
+  const dispatchResult = anchor.dispatchEvent(event);
+  assert.equal(dispatchResult, false, 'guarded link should cancel default navigation');
+  await delay();
+  assert.equal(confirmCount, 1);
+  assert.equal(dom.window.location.href, originalHref);
+  assert.equal(context.__bnUnifiedGuard.lastNavigation, null);
+});
+
+test('guard allows navigation without prompt when solved', async () => {
+  const dom = new JSDOM(`
+    <table>
+      <tr>
+        <td></td>
+        <td><a href="/problem/42">Problem 42</a></td>
+        <td><a id="sub" href="/submission/888">View</a></td>
+      </tr>
+    </table>
+  `, { url: 'http://example.com/submissions?problem_id=42', runScripts: 'outside-only' });
+
+  dom.window.fetch = async (url) => {
+    if (url.startsWith('/api/submissions')) {
+      return { ok: true, json: async () => ({ items: [{}] }) };
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  };
+  let confirmCount = 0;
+  dom.window.confirm = () => { confirmCount += 1; return false; };
+  const { context } = loadGuardModule({
+    context: dom.getInternalVMContext(),
+    overrides: {
+      fetch: dom.window.fetch,
+      confirm: dom.window.confirm,
+    },
+  });
+
+  const anchor = dom.window.document.getElementById('sub');
+  const originalHref = dom.window.location.href;
+  const event = new dom.window.MouseEvent('click', { bubbles: true, cancelable: true });
+  const dispatchResult = anchor.dispatchEvent(event);
+  assert.equal(dispatchResult, false, 'guard should handle navigation');
+  await delay();
+  assert.equal(confirmCount, 0);
+  assert.equal(context.__bnUnifiedGuard.lastNavigation, 'http://example.com/submission/888');
+});


### PR DESCRIPTION
## Summary
- replace legacy guard heuristics with a unified module that queries the current user's 100-point submissions, caches results, and falls back to the problem page badge when necessary
- add navigation tracking, caching helpers, and robust click interception for submissions/statistics pages while exposing control hooks for tests
- introduce a Node-based test harness with jsdom to cover solved, unsolved, fallback, caching, and routing scenarios

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_b_68d391bcfd34832198a532943f944ace