### PR TITLE
Remove submenu separators for copy and plan options

### DIFF
--- a/main.js
+++ b/main.js
@@ -566,11 +566,11 @@ window.getCurrentUserId = getCurrentUserId;
     }
 
     #bn-copy-options {
-      margin-left: 24px; display: ${enableCopy ? 'block' : 'none'}; padding-top: 8px; border-top: 1px solid var(--bn-border-subtle);
+      margin-left: 24px; display: ${enableCopy ? 'block' : 'none'}; padding-top: 8px;
       margin-top: 8px;
     }
     #bn-plan-options {
-      margin-left: 24px; display: ${enablePlanAdder ? 'block' : 'none'}; padding-top: 8px; border-top: 1px solid var(--bn-border-subtle);
+      margin-left: 24px; display: ${enablePlanAdder ? 'block' : 'none'}; padding-top: 8px;
       margin-top: 8px;
     }
     #bn-title-options, #bn-user-options {


### PR DESCRIPTION
## Summary
- remove the horizontal separators from the secondary copy and plan option menus so they appear without divider lines

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e4d87bde488321b7ccbff6c9dae25b