### PR TITLE
Allow content scripts to read bundled user data

### DIFF
--- a/Better-Names-for-7FA4/manifest.json
+++ b/Better-Names-for-7FA4/manifest.json
@@ -29,6 +29,16 @@
       "run_at": "document_end"
     }
   ],
+  "web_accessible_resources": [
+    {
+      "resources": [
+        "data/users.json"
+      ],
+      "matches": [
+        "http://*.7fa4.cn:8888/*"
+      ]
+    }
+  ],
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",


### PR DESCRIPTION
## Summary
- expose data/users.json as a web-accessible resource so the content script can load the username color mappings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ef19724090833195af631dc3a563a4