### PR TITLE
Remove spacing separators from secondary option menus

### DIFF
--- a/Better-Names-for-7FA4/content/main.js
+++ b/Better-Names-for-7FA4/content/main.js
@@ -553,12 +553,10 @@ window.getCurrentUserId = getCurrentUserId;
     }
 
     #bn-plan-options {
-      margin-left: 24px; display: ${enablePlanAdder ? 'block' : 'none'}; padding-top: 8px;
-      margin-top: 8px;
+      margin-left: 24px; display: ${enablePlanAdder ? 'block' : 'none'};
     }
     #bn-title-options, #bn-user-options {
-      margin-left: 24px; padding-top: 8px; border-top: 1px solid var(--bn-border-subtle);
-      margin-top: 8px;
+      margin-left: 24px;
     }
     #bn-title-options { display: ${isFinite(maxTitleUnits) ? 'block' : 'none'}; }
     #bn-user-options  { display: ${isFinite(maxUserUnits) ? 'block' : 'none'}; }


### PR DESCRIPTION
## Summary
- remove the border and extra spacing before the secondary options for title/user truncation and plan additions
- keep the submenu items visually connected to their associated toggles

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ef47959c38833186206e1864af8c56