### PR TITLE
Revamp popup UI with HarmonyOS-inspired design

### DIFF
--- a/Better-Names-for-7FA4/submitter/popup.css
+++ b/Better-Names-for-7FA4/submitter/popup.css
@@ -1,7 +1,198 @@
-.button{
-	width: 150px;
+:root {
+    color-scheme: light;
+    --panel-width: 320px;
+    --panel-padding: 20px;
+    --radius-lg: 18px;
+    --radius-md: 12px;
+    --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.18);
+    --shadow-md: 0 8px 18px rgba(0, 0, 0, 0.22);
+    --primary: #1a73e8;
+    --primary-hover: #3485f0;
+    --accent: #4caf50;
+    --text-primary: #212121;
+    --text-secondary: rgba(33, 33, 33, 0.72);
+    --bg-blur: rgba(255, 255, 255, 0.72);
+    font-family: "HarmonyOS Sans SC", "Noto Sans SC", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
 }
 
-.text {
-	font-size: 12;
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    min-width: 320px;
+    padding: 18px;
+    background: linear-gradient(160deg, rgba(52, 148, 230, 0.35), rgba(236, 110, 173, 0.25));
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.panel {
+    width: var(--panel-width);
+    padding: var(--panel-padding);
+    border-radius: var(--radius-lg);
+    background: var(--bg-blur);
+    backdrop-filter: blur(14px);
+    -webkit-backdrop-filter: blur(14px);
+    box-shadow: var(--shadow-md);
+    color: var(--text-primary);
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.heading {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.title {
+    font-size: 1.6rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    margin: 0;
+}
+
+.subtitle {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.icon-btn {
+    border: none;
+    background: transparent;
+    border-radius: 50%;
+    padding: 8px;
+    cursor: pointer;
+    transition: background 0.3s ease, transform 0.15s ease;
+    color: rgba(0, 0, 0, 0.7);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.icon-btn svg {
+    width: 22px;
+    height: 22px;
+    fill: currentColor;
+}
+
+.icon-btn:hover {
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.icon-btn:active {
+    transform: translateY(1px) scale(0.98);
+    background: rgba(0, 0, 0, 0.12);
+}
+
+.status-card {
+    border-radius: var(--radius-md);
+    padding: 16px;
+    background: rgba(255, 255, 255, 0.65);
+    box-shadow: var(--shadow-sm);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.status-label {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: rgba(0, 0, 0, 0.55);
+}
+
+.status-value {
+    font-size: 1.05rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.actions {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.btn {
+    border: none;
+    border-radius: 14px;
+    padding: 12px 16px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    cursor: pointer;
+    transition: transform 0.12s ease, box-shadow 0.12s ease, background 0.3s ease;
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 44px;
+}
+
+.btn:focus {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(26, 115, 232, 0.25);
+}
+
+.btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.18);
+}
+
+.btn:active {
+    transform: translateY(1px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.24);
+}
+
+.primary-btn {
+    background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+    color: #fff;
+}
+
+.secondary-btn {
+    background: rgba(26, 115, 232, 0.12);
+    color: var(--primary);
+}
+
+.secondary-btn:hover {
+    background: rgba(26, 115, 232, 0.18);
+}
+
+.tertiary-btn {
+    background: rgba(0, 0, 0, 0.05);
+    color: var(--text-primary);
+}
+
+.tertiary-btn:hover {
+    background: rgba(0, 0, 0, 0.1);
+}
+
+.tips {
+    font-size: 0.78rem;
+    color: rgba(0, 0, 0, 0.6);
+    margin: 0;
+    line-height: 1.4;
+}
+
+.tips p {
+    margin: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+    }
 }

--- a/Better-Names-for-7FA4/submitter/popup.html
+++ b/Better-Names-for-7FA4/submitter/popup.html
@@ -1,19 +1,40 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="zh-CN">
 <head>
-	<meta charset="utf-8">
-	<link rel="stylesheet" href="popup.css">
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="popup.css">
+    <title>Better Names for 7FA4</title>
 </head>
-
 <body>
-	<p id="loginStatus" class="text"></p>
-	<button id="sendPage" class="button">发送提交</button>
-	<button id="sendVjPage" class="button">发送提交 | vjudge 题号</button>
-	<button id="getCookies" class="button">更新 7FA4 登录信息</button>
-	<script src="jquery-3.7.0.min.js"></script>
-	<script src="jquery.cookie.js"></script>
-	<script src="popup.js"></script>
+    <div class="panel">
+        <header class="header">
+            <div class="heading">
+                <h1 class="title">Better Names</h1>
+                <p class="subtitle">HarmonyOS 风格的 7FA4 助手</p>
+            </div>
+            <button class="icon-btn" id="settingsBtn" title="打开设置">
+                <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+                    <path d="M8 4.754a3.246 3.246 0 1 0 0 6.492 3.246 3.246 0 0 0 0-6.492zM5.754 8a2.246 2.246 0 1 1 4.492 0 2.246 2.246 0 0 1-4.492 0z" />
+                    <path d="M9.796 1.343c-.527-1.79-3.065-1.79-3.592 0l-.094.319a.873.873 0 0 1-1.255.52l-.292-.16a2.887 2.887 0 0 0-2.54 2.541l.159.292a.873.873 0 0 1-.52 1.255l-.319.094a2.887 2.887 0 0 0 0 3.592l.319.094a.873.873 0 0 1 .52 1.255l-.16.292a2.887 2.887 0 0 0 2.54 2.54l.292-.159a.873.873 0 0 1 1.255.52l.094.319a2.887 2.887 0 0 0 3.592 0l.094-.319a.873.873 0 0 1 1.255-.52l.292.16a2.887 2.887 0 0 0 2.54-2.541l-.159-.292a.873.873 0 0 1 .52-1.255l.319-.094a2.887 2.887 0 0 0 0-3.592l-.319-.094a.873.873 0 0 1-.52-1.255l.16-.292a2.887 2.887 0 0 0-2.541-2.54l-.292.159a.873.873 0 0 1-1.255-.52l-.094-.319z" />
+                </svg>
+            </button>
+        </header>
+        <section class="status-card" aria-live="polite">
+            <div class="status-label">登录状态</div>
+            <div id="loginStatus" class="status-value">正在检测...</div>
+        </section>
+        <section class="actions">
+            <button id="sendPage" class="btn primary-btn">发送提交</button>
+            <button id="sendVjPage" class="btn secondary-btn">发送提交 | vjudge 题号</button>
+            <button id="getCookies" class="btn tertiary-btn">更新 7FA4 登录信息</button>
+        </section>
+        <footer class="tips">
+            <p>按钮悬停与按压均带有柔和的触感反馈，符合 HarmonyOS 设计语言。</p>
+        </footer>
+    </div>
+    <script src="jquery-3.7.0.min.js"></script>
+    <script src="jquery.cookie.js"></script>
+    <script src="popup.js"></script>
 </body>
-
 </html>

--- a/Better-Names-for-7FA4/submitter/popup.js
+++ b/Better-Names-for-7FA4/submitter/popup.js
@@ -97,6 +97,17 @@ document.getElementById('sendVjPage').addEventListener('click', async () => {
 	});
 });
 
+const settingsBtn = document.getElementById('settingsBtn');
+if (settingsBtn) {
+	settingsBtn.addEventListener('click', () => {
+		if (chrome.runtime.openOptionsPage) {
+			chrome.runtime.openOptionsPage();
+		} else {
+			alert('请在扩展管理页面中调整 Better Names for 7FA4 设置。');
+		}
+	});
+}
+
 chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 	if(request.type != 'GCookies') return;
 	let window_host = sender.origin;


### PR DESCRIPTION
## Summary
- rebuild the popup layout with a HarmonyOS-style header, status card, and action area while preserving existing controls
- refresh the popup styling with glassmorphism, rounded cards, and animated button feedback using pure HTML/CSS
- add a settings button handler that opens the options page when available for a more complete header interaction

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_b_68f1c1924250833199ff75b77cee139d