### PR TITLE
Revamp submitter popup to match panel aesthetics

### DIFF
--- a/Better-Names-for-7FA4/submitter/popup.css
+++ b/Better-Names-for-7FA4/submitter/popup.css
@@ -1,7 +1,214 @@
-.button{
-	width: 150px;
+:root {
+  color-scheme: light dark;
+  --bn-bg: #f5f7fb;
+  --bn-bg-subtle: rgba(255, 255, 255, 0.65);
+  --bn-bg-grad-1: rgba(255, 255, 255, 0.92);
+  --bn-bg-grad-2: rgba(255, 255, 255, 0.82);
+  --bn-border: rgba(15, 23, 42, 0.08);
+  --bn-border-strong: rgba(15, 23, 42, 0.16);
+  --bn-text: #1f2937;
+  --bn-text-muted: #64748b;
+  --bn-accent: #2563eb;
+  --bn-accent-soft: rgba(37, 99, 235, 0.12);
+  --bn-shadow: 0 18px 45px rgba(15, 23, 42, 0.15);
+  --bn-radius-lg: 18px;
+  --bn-radius-md: 12px;
+  --bn-radius-sm: 8px;
+  font-family: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
 }
 
-.text {
-	font-size: 12;
+body {
+  margin: 0;
+  min-width: 320px;
+  background: radial-gradient(120% 120% at 50% 0%, rgba(37, 99, 235, 0.18) 0%, rgba(14, 165, 233, 0.12) 28%, rgba(15, 23, 42, 0.02) 64%), var(--bn-bg);
+  padding: 18px;
+  color: var(--bn-text);
+  font-family: inherit;
+  display: flex;
+  justify-content: center;
+}
+
+.bn-popup {
+  width: 100%;
+  max-width: 360px;
+  background: linear-gradient(160deg, var(--bn-bg-grad-1) 0%, var(--bn-bg-grad-2) 40%, rgba(248, 250, 252, 0.95) 100%);
+  border: 1px solid var(--bn-border);
+  border-radius: var(--bn-radius-lg);
+  box-shadow: var(--bn-shadow);
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.bn-popup__header {
+  padding: 20px 24px 16px;
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.16) 0%, rgba(37, 99, 235, 0.04) 52%, rgba(255, 255, 255, 0) 100%);
+  border-bottom: 1px solid var(--bn-border);
+}
+
+.bn-popup__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--bn-accent);
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.bn-popup__title {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--bn-text);
+}
+
+.bn-popup__subtitle {
+  margin: 6px 0 0;
+  font-size: 13px;
+  color: var(--bn-text-muted);
+  line-height: 1.5;
+}
+
+.bn-popup__body {
+  padding: 18px 24px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.bn-status {
+  border: 1px solid var(--bn-border);
+  border-radius: var(--bn-radius-md);
+  background: rgba(255, 255, 255, 0.72);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bn-status__label {
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--bn-text-muted);
+}
+
+.bn-status__value {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--bn-text);
+  min-height: 20px;
+}
+
+.bn-popup__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.bn-button {
+  appearance: none;
+  border: 1px solid var(--bn-border-strong);
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--bn-text);
+  border-radius: var(--bn-radius-md);
+  padding: 12px 16px;
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+}
+
+.bn-button:hover,
+.bn-button:focus-visible {
+  background: rgba(255, 255, 255, 1);
+  border-color: var(--bn-accent);
+  box-shadow: 0 10px 24px rgba(37, 99, 235, 0.18);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.bn-button:active {
+  transform: translateY(0);
+  box-shadow: 0 6px 16px rgba(37, 99, 235, 0.16);
+}
+
+.bn-button--primary {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.92) 0%, rgba(14, 165, 233, 0.78) 100%);
+  border-color: transparent;
+  color: #ffffff;
+  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.35);
+}
+
+.bn-button--primary:hover,
+.bn-button--primary:focus-visible {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 1) 0%, rgba(14, 165, 233, 0.92) 100%);
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.4);
+}
+
+.bn-popup__footer {
+  padding: 14px 24px 20px;
+  border-top: 1px solid var(--bn-border);
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.bn-popup__hint {
+  margin: 0;
+  font-size: 12px;
+  color: var(--bn-text-muted);
+  line-height: 1.5;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bn-bg: #10131a;
+    --bn-bg-subtle: rgba(17, 24, 39, 0.75);
+    --bn-bg-grad-1: rgba(30, 41, 59, 0.95);
+    --bn-bg-grad-2: rgba(17, 24, 39, 0.92);
+    --bn-border: rgba(148, 163, 184, 0.18);
+    --bn-border-strong: rgba(148, 163, 184, 0.32);
+    --bn-text: #e2e8f0;
+    --bn-text-muted: #94a3b8;
+    --bn-accent: #60a5fa;
+    --bn-accent-soft: rgba(96, 165, 250, 0.2);
+    --bn-shadow: 0 18px 45px rgba(15, 23, 42, 0.45);
+  }
+
+  body {
+    background: radial-gradient(120% 120% at 50% 0%, rgba(59, 130, 246, 0.18) 0%, rgba(14, 165, 233, 0.12) 32%, rgba(15, 23, 42, 0.32) 80%), var(--bn-bg);
+  }
+
+  .bn-popup {
+    background: linear-gradient(160deg, rgba(17, 24, 39, 0.92) 0%, rgba(17, 24, 39, 0.86) 60%, rgba(30, 41, 59, 0.75) 100%);
+  }
+
+  .bn-status {
+    background: rgba(17, 24, 39, 0.85);
+  }
+
+  .bn-button {
+    background: rgba(17, 24, 39, 0.82);
+    color: var(--bn-text);
+  }
+
+  .bn-button:hover,
+  .bn-button:focus-visible {
+    background: rgba(17, 24, 39, 0.92);
+  }
+
+  .bn-popup__footer {
+    background: rgba(17, 24, 39, 0.86);
+  }
 }

--- a/Better-Names-for-7FA4/submitter/popup.html
+++ b/Better-Names-for-7FA4/submitter/popup.html
@@ -1,19 +1,33 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="zh-CN">
 <head>
-	<meta charset="utf-8">
-	<link rel="stylesheet" href="popup.css">
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="popup.css">
 </head>
-
 <body>
-	<p id="loginStatus" class="text"></p>
-	<button id="sendPage" class="button">发送提交</button>
-	<button id="sendVjPage" class="button">发送提交 | vjudge 题号</button>
-	<button id="getCookies" class="button">更新 7FA4 登录信息</button>
-	<script src="jquery-3.7.0.min.js"></script>
-	<script src="jquery.cookie.js"></script>
-	<script src="popup.js"></script>
+  <div class="bn-popup" role="dialog" aria-labelledby="bn-popup-title" aria-describedby="bn-popup-subtitle">
+    <header class="bn-popup__header">
+      <div class="bn-popup__badge">Better Names for 7FA4</div>
+      <h1 id="bn-popup-title" class="bn-popup__title">提交助手</h1>
+      <p id="bn-popup-subtitle" class="bn-popup__subtitle">快速同步你的提交记录并保持登录状态</p>
+    </header>
+    <main class="bn-popup__body">
+      <div class="bn-status">
+        <span class="bn-status__label">7FA4 登录状态</span>
+        <p id="loginStatus" class="bn-status__value">&nbsp;</p>
+      </div>
+      <div class="bn-popup__actions" role="group" aria-label="提交操作">
+        <button id="sendPage" class="bn-button" type="button">发送提交</button>
+        <button id="sendVjPage" class="bn-button" type="button">发送提交 · vjudge 题号</button>
+        <button id="getCookies" class="bn-button bn-button--primary" type="button">更新 7FA4 登录信息</button>
+      </div>
+    </main>
+    <footer class="bn-popup__footer">
+      <p class="bn-popup__hint">提示：请在对应提交详情页或 7FA4 站点打开此面板以确保信息完整。</p>
+    </footer>
+  </div>
+  <script src="jquery-3.7.0.min.js"></script>
+  <script src="jquery.cookie.js"></script>
+  <script src="popup.js"></script>
 </body>
-
 </html>


### PR DESCRIPTION
## Summary
- redesign the submitter popup markup to include a structured header, status block, and footer matching the Better Names for 7FA4 panel experience
- replace minimal styles with a comprehensive theme that mirrors the main panel, including gradients, shadows, and dark mode support
- keep existing submission actions and login status display while presenting them with improved hierarchy and accessibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68f1dfff535c8331ac72ae71a59c9d29