### PR TITLE
Add toast notification after plan updates

### DIFF
--- a/Better-Names-for-7FA4/manifest.json
+++ b/Better-Names-for-7FA4/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Better Names for 7FA4",
-  "version": "6.0.0.11",
+  "version": "6.0.0.12",
   "description": "强大的 7FA4 用户名与颜色映射插件",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary
- add an in-page toast that appears after plan submissions complete without requiring confirmation
- update the displayed build label and manifest version to 6.0.0 SP12 Developer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f4ae13fc448331b3a3f48bf315cd51