### PR TITLE
Enable row selection with animation for plan adder

### DIFF
--- a/Better-Names-for-7FA4/manifest.json
+++ b/Better-Names-for-7FA4/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Better Names for 7FA4",
-  "version": "6.0.0.12",
+  "version": "6.0.0.13",
   "description": "强大的 7FA4 用户名与颜色映射插件",
   "permissions": [
     "storage",


### PR DESCRIPTION
## Summary
- allow selecting plan entries by clicking anywhere on the problem row and keep checkbox sync
- add a pulse highlight animation when toggling plan selections
- bump the developer version to 6.0.0 SP13 / 6.0.0.13

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f4eba860a48331b73b3d5d0a2ef667