### PR TITLE
Fix plan selector intercepting anchor navigation

### DIFF
--- a/Better-Names-for-7FA4/content/main.js
+++ b/Better-Names-for-7FA4/content/main.js
@@ -2201,6 +2201,7 @@ window.getCurrentUserId = getCurrentUserId;
     const hasModifier = event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
     if (interactive && interactive !== cb) {
       if (hasModifier) return false;
+      if (interactive.matches?.('a[href]')) return false;
       event.preventDefault();
       event.stopPropagation();
     }


### PR DESCRIPTION
## Summary
- allow plan-row anchors with href attributes to bypass the selection handler
- keep selection toggling behavior for non-interactive clicks when plan mode is enabled

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_b_68f5d215ff6483319ee76293e671ee4d