### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-database.yml
+++ b/.github/workflows/run-database.yml
@@ -1,4 +1,6 @@
 name: Run Database Script
+permissions:
+  contents: write
 
 on:
   workflow_dispatch:  # 手动触发


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/1](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/1)

To address this, add an explicit `permissions` block at the appropriate location. Since only a single job is present, you can add the `permissions` block at the workflow (top) level—this will apply to all jobs. This workflow commits and pushes to the repository, so it requires `contents: write` permissions. To adhere to the principle of least privilege, set `contents: write` at the workflow root (just after the `name: ...` line and before `on:`), so that only the required permissions are granted.

No new methods, imports, or further changes are required—it's a single YAML addition.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
