### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/Better-Names-for-7FA4/content/main.js
+++ b/Better-Names-for-7FA4/content/main.js
@@ -1817,6 +1817,8 @@ window.getCurrentUserId = getCurrentUserId;
       }
     }
     if (!pid) return null;
+    // Only allow problem IDs that are all-digits (positive integers)
+    if (!/^\d+$/.test(String(pid))) return null;
     return String(pid);
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/4](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/4)

The best way to fix this issue is to validate and sanitize the `problemId` obtained from the DOM, ensuring it only consists of digits (i.e., is a positive integer), before using it to construct URLs like `/problem/${problemId}/skip`, setting attributes, or using it anywhere that could be interpreted as code/HTML/URL. 
- This can be done by updating the `getProblemIdFromRow` function to ensure that it only ever returns strings of digits, or by validating just before using its result.
- The safest solution is to validate the value at the point where it is extracted, so that all downstream code benefits from the guarantee.
- Add an explicit check in `getProblemIdFromRow` to confirm that `pid` matches `/^\d+$/` or similar before returning it; if it does not, return `null`.
- This requires editing the `getProblemIdFromRow` function starting at line 1799.
- No new imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
