### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/Better-Names-for-7FA4/content/main.js
+++ b/Better-Names-for-7FA4/content/main.js
@@ -1452,6 +1452,15 @@ window.getCurrentUserId = getCurrentUserId;
     if (codePoint <= 0xFFFF) return 3;
     return 4;
   }
+  function escapeHtml(text) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
   function truncateByUnits(str, maxU) {
     if (!isFinite(maxU)) return str;
     let used = 0, out = '';
@@ -1753,11 +1762,13 @@ window.getCurrentUserId = getCurrentUserId;
 
     let finalText = '';
     if (info) {
-      finalText = (img ? '\u00A0' : '') + info.name;
+      // If info.name could potentially contain unsafe chars, escape it as well:
+      finalText = (img ? '\u00A0' : '') + escapeHtml(info.name);
       const c = palette[info.colorKey];
       if (c) a.style.color = c;
     } else {
-      finalText = (img ? '\u00A0' : '') + truncateByUnits(baseText || a.textContent.trim(), maxUserUnits);
+      const safeTruncated = escapeHtml(truncateByUnits(baseText || a.textContent.trim(), maxUserUnits));
+      finalText = (img ? '\u00A0' : '') + safeTruncated;
     }
 
     Array.from(a.childNodes).forEach(n => { if (n.nodeType === Node.TEXT_NODE) n.remove(); });


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/2](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/2)

To fix the identified problem, we must ensure that any text extracted from the DOM and reinserted as HTML is properly escaped to prevent interpretation as markup. Specifically, we must escape metacharacters (`& < > " ' /`, etc.) in `finalText` before it is used with `insertAdjacentHTML`. We will do this by adding an `escapeHtml` function that escapes these characters. When `finalText` does not intentionally contain markup (i.e., for the 'else' branch in `processUserLink`), we will escape it before insertion.

- Add an `escapeHtml` utility function in `Better-Names-for-7FA4/content/main.js`.
- Update the `processUserLink` function so that in the 'else' branch (where `finalText` is constructed from DOM text), we apply `escapeHtml` before concatenation.
- Ensure that only pure text (not HTML) is escaped—do **not** escape in the 'info' case, since that appears to be trusted metadata (from `info.name`) and could already be sanitized/trusted; but for defense in depth, you may choose to escape this as well if not 100% sure about its provenance.
- The change is entirely within `Better-Names-for-7FA4/content/main.js`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
