### PR TITLE
Fix save action bar positioning when zoomed

### DIFF
--- a/Better-Names-for-7FA4/content/main.js
+++ b/Better-Names-for-7FA4/content/main.js
@@ -555,8 +555,7 @@ window.getCurrentUserId = getCurrentUserId;
     .bn-color-actions { display: flex; gap: 8px; }
     .bn-color-actions .bn-btn { flex: 1; padding: 10px 16px; font-size: 12px; }
     .bn-save-actions {
-      position: absolute;
-      left: 0; right: 0;
+      position: sticky;
       bottom: var(--bn-version-h);
       height: var(--bn-savebar-h);
       padding: 0 20px;
@@ -566,6 +565,7 @@ window.getCurrentUserId = getCurrentUserId;
       opacity: 0; pointer-events: none; transform: translateY(12px);
       transition: opacity .28s cubic-bezier(.4, 0, .2, 1), transform .28s cubic-bezier(.4, 0, .2, 1);
       will-change: opacity, transform;
+      z-index: 5;
     }
     .bn-save-actions.bn-visible {
       opacity: 1; pointer-events: auto; transform: translateY(0);


### PR DESCRIPTION
## Summary
- change the configuration action bar to use sticky positioning so it stays docked to the bottom of the panel
- add a stacking context to keep the bar above scrollable content while visible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68fdb8072740832aa43d76fb858a3194