### PR TITLE
Disable dragging for panel settings trigger

### DIFF
--- a/Better-Names-for-7FA4/content/panel/panel.js
+++ b/Better-Names-for-7FA4/content/panel/panel.js
@@ -800,10 +800,13 @@
     }
     if (!__bn_raf) __bn_raf = requestAnimationFrame(__bn_tick);
   };
-  if (window.PointerEvent) {
-    trigger.addEventListener('pointerdown', __bn_onDown, { passive: false });
-  } else {
-    trigger.addEventListener('mousedown', __bn_onDown, { passive: false });
+  const enableTriggerDragging = false;
+  if (enableTriggerDragging) {
+    if (window.PointerEvent) {
+      trigger.addEventListener('pointerdown', __bn_onDown, { passive: false });
+    } else {
+      trigger.addEventListener('mousedown', __bn_onDown, { passive: false });
+    }
   }
 
   pinBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- prevent the settings gear trigger from registering pointer down events so it can no longer be dragged around the screen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68fe2639f100832a9b5fb5a6574fc59b