### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/Better-Names-for-7FA4/content/panel/panel.js
+++ b/Better-Names-for-7FA4/content/panel/panel.js
@@ -1605,10 +1605,23 @@
     return { qualifies: true, insertIndex: computedIndex, questionIcon: true };
   }
 
+  // Utility to safely construct a problem URL path segment
+  function safeProblemUrl(problemId) {
+    // Accept only strings of digits
+    if (typeof problemId !== 'string' && typeof problemId !== 'number') return null;
+    const pidStr = String(problemId);
+    if (!/^\d+$/.test(pidStr)) return null;
+    return `/problem/${pidStr}/skip`;
+  }
+
   function createQuickSkipButton(problemId) {
     const btn = document.createElement('a');
     btn.setAttribute('data-bn-quick-skip', '1');
-    btn.href = `/problem/${problemId}/skip`;
+    const safeHref = safeProblemUrl(problemId);
+    if (!safeHref) {
+      throw new Error('Invalid problemId in createQuickSkipButton: ' + problemId);
+    }
+    btn.href = safeHref;
     btn.dataset.problemId = String(problemId);
     btn.className = 'bn-quick-skip';
     btn.innerHTML = '<i class="coffee icon" aria-hidden="true"></i><span>Skip</span>';


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/5](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/5)

To fix the problem, we should strictly enforce that `problemId` used in the URL path in `createQuickSkipButton` is safe and cannot be reinterpreted as HTML or otherwise cause problems when used as a URL attribute. The existing validation (`/^\d+$/`) is sufficient for now, but to future-proof and make the code more robust, we should:
- Explicitly ensure that `problemId` is a string of digits before using it.
- Consider using `textContent` for inserting text, and avoid using `innerHTML` when inserting user-controlled data.
- Where the destination is an attribute (like `href`), set the attribute with a value that is encoded and validated.
- Refactor the logic to throw or handle if somehow a non-numeric value sneaks through.

Specifically:
- In `createQuickSkipButton`, before setting the `href` attribute, check that `problemId` is a non-empty string of digits (`/^\d+$/`). If not, do not proceed or throw an error.
- Optionally, create a utility function like `safeProblemUrl(problemId)` that returns `/problem/${problemId}/skip` only if `problemId` passes the numeric test; else throws/reports an error.

Edit regions:
- In function `createQuickSkipButton` (lines around 1608–1643): add an explicit check and utility for safe interpolation.

No external library is strictly needed, as the validation is trivial.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
