### PR TITLE
Embed default cookie in crawler

### DIFF
--- a/database/run.ps1
+++ b/database/run.ps1
@@ -3,7 +3,7 @@ python -m venv venv
 .\venv\Scripts\Activate.ps1
 pip install aiohttp beautifulsoup4 lxml
 
-# run
+# run（请先在 main.py 里把 DEFAULT_COOKIE 换成最新 Cookie 或设置环境变量 JX_COOKIE）
 python main.py
 
 pause


### PR DESCRIPTION
## Summary
- embed the default cookie string directly in the Python crawler so it runs without PowerShell setup
- always send the cookie header with requests and update the login guidance to point to the new constant
- streamline the PowerShell helper script now that no cookie export is required

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_69015c8a6320832ab460608fb1cd06b1