### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow that is manually triggered
 
 name: Manual workflow
+permissions:
+  contents: none
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/7](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/7)

To fix the problem, add a `permissions` block to limit the GITHUB_TOKEN permissions for the workflow. Since the job only echoes a greeting and does not require any repository or API permissions, the most restrictive setting is safe: set all permissions to `none`. This can be done either at the root (affecting all jobs) or within the specific job. The preferred approach is at the root for clarity and future-proofing. This means adding the following near the top of the workflow (after the `name:` and before `jobs:`):  

```yaml
permissions:
  contents: none
```

**Specifics:**  
- Add the `permissions:` block after the `name: Manual workflow` line (line 3).  
- Set `contents: none` to prohibit all repository write or read by GITHUB_TOKEN.

No other imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
