### PR TITLE
Potential fix for code scanning alert no. 12: Incomplete URL substring sanitization

### DIFF
--- a/build.py
+++ b/build.py
@@ -310,11 +310,12 @@ class DependencyBuilder:
             headers = {}
             
             # 设置认证头
-            if "github.com" in repo_url:
+            host = urlparse(repo_url).hostname
+            if host == "github.com" or (host and host.endswith(".github.com")):
                 github_token = os.environ.get('GITHUB_TOKEN')
                 if github_token:
                     headers['Authorization'] = f'token {github_token}'
-            elif "jx.7fa4.cn" in repo_url:
+            elif host == "jx.7fa4.cn" or (host and host.endswith(".jx.7fa4.cn")):
                 gitlab_token = os.environ.get('GITLAB_TOKEN')
                 if gitlab_token:
                     headers['PRIVATE-TOKEN'] = gitlab_token


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/12](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/12)

The best way to fix this issue is to parse the URL using `urllib.parse.urlparse`, and then check the hostname field for exact matches. For more flexibility, you can check for either an exact match (`== "github.com"`) or a valid subdomain match (`endswith(".github.com")`). 

Change the lines:
```python
313: if "github.com" in repo_url:
317: elif "jx.7fa4.cn" in repo_url:
```
so instead they robustly parse the host portion of `repo_url` and compare appropriately.

You will need to:
- Use `urlparse` to extract the hostname.
- Change the substring checks to host comparison checks.
- Add required imports (already present).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
