### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL substring sanitization

### DIFF
--- a/build.py
+++ b/build.py
@@ -222,7 +222,8 @@ class DependencyBuilder:
     def select_best_asset(self, assets, release_info, repo_url):
         """选择最佳的 asset（优先非源码包）"""
         # GitHub 和 GitLab 的 assets 结构不同
-        if "github.com" in repo_url:
+        host = urlparse(repo_url).hostname
+        if host == "github.com":
             # GitHub: assets 是列表
             asset_list = assets
         else:
@@ -244,7 +245,7 @@ class DependencyBuilder:
         source_assets = []
         
         for asset in asset_list:
-            if "github.com" in repo_url:
+            if host == "github.com":
                 name = asset.get("name", "").lower()
                 url = asset.get("browser_download_url", "")
             else:
@@ -274,7 +275,7 @@ class DependencyBuilder:
             return selected_url, selected_name
         else:
             # 回退到第一个 asset
-            if asset_list and "github.com" in repo_url:
+            if asset_list and host == "github.com":
                 selected_url = asset_list[0].get("browser_download_url")
                 selected_name = asset_list[0].get("name")
             elif asset_list:


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/11](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/11)

To robustly determine if a given URL is hosted on `github.com`, we should use Python's `urlparse` to extract the hostname from the URL and check if it matches `"github.com"` or subdomains thereof (though in this usage, presumably only the main domain is valid). All instances where `"github.com" in repo_url` is used should be replaced with a check like:

```python
urlparse(repo_url).hostname == "github.com"
```

or, if subdomains are to be handled:

```python
host = urlparse(repo_url).hostname
is_github = host == "github.com" or (host and host.endswith(".github.com"))
```

But for standard usage, only `"github.com"` is appropriate because asset APIs are only available under that base domain.

Changes should be made at every point in the `select_best_asset` method where the `"github.com" in repo_url` check is used:
- Lines 225, 247, and 277.

No new methods are required; the standard library's `urlparse` is already imported. Any repeated use can assign `host = urlparse(repo_url).hostname` at the start of the method for clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
