### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/build.py
+++ b/build.py
@@ -156,7 +156,8 @@ class DependencyBuilder:
         """获取最新 release 信息"""
         parsed_url = urlparse(repo_url)
         
-        if "github.com" in repo_url:
+        # 只允许真正的 github.com 域名（不允许类似 evil-github.com.xyz）
+        if parsed_url.hostname and parsed_url.hostname.lower() == "github.com":
             # GitHub 仓库
             path_parts = parsed_url.path.strip('/').split('/')
             if len(path_parts) < 2:


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/8](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/8)

The fix is to properly check the parsed hostname of the URL, ensuring that only URLs genuinely belonging to the GitHub domain are recognized as such. Replace the substring check `"github.com" in repo_url` with a test on `parsed_url.hostname`, checking if it matches exactly `"github.com"` or any safe subdomains if desired. This should be implemented in the `get_latest_release_info` method in build.py, specifically around line 159. Ensure that if `parsed_url.hostname` is `None` (e.g., malformed URL), the code does not proceed with further processing. This change maintains current functionality for legitimate GitHub URLs but avoids security bugs due to substring matches.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
