### PR TITLE
Potential fix for code scanning alert no. 14: Useless regular-expression character escape

### DIFF
--- a/Better-Names-for-7FA4/content/main.js
+++ b/Better-Names-for-7FA4/content/main.js
@@ -952,7 +952,7 @@ window.getCurrentUserId = getCurrentUserId;
       if (text && code) {
         const escaped = escapeRegExp(code);
         if (escaped) {
-          const pattern = new RegExp(`^${escaped}\s*[-–—·:：]*\s*`, 'i');
+          const pattern = new RegExp(`^${escaped}\\s*[-–—·:：]*\\s*`, 'i');
           const stripped = text.replace(pattern, '').trim();
           if (stripped) text = stripped;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/14](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/14)

To fix this issue, ensure that each `\s` in the RegExp pattern string, when written as a string literal (or template literal), is properly escaped as `\\s`. This ensures that RegExp receives a pattern with an actual `\s`, which matches a whitespace character class. Specifically, update line 955 in `Better-Names-for-7FA4/content/main.js` to use `\\s*` instead of `\s*` in all places where whitespace is intended.

No new imports or helpers are necessary—simply correct the escape sequences on line 955.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
