### PR TITLE
Potential fix for code scanning alert no. 13: Useless regular-expression character escape

### DIFF
--- a/Better-Names-for-7FA4/content/main.js
+++ b/Better-Names-for-7FA4/content/main.js
@@ -952,7 +952,7 @@ window.getCurrentUserId = getCurrentUserId;
       if (text && code) {
         const escaped = escapeRegExp(code);
         if (escaped) {
-          const pattern = new RegExp(`^${escaped}\s*[-–—·:：]*\s*`, 'i');
+          const pattern = new RegExp(`^${escaped}\\s*[-–—·:：]*\\s*`, 'i');
           const stripped = text.replace(pattern, '').trim();
           if (stripped) text = stripped;
         }


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/13](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/13)

The problem is in using the `RegExp` constructor with a string template that directly embeds `\s`. In JavaScript string literals, to get a regex escape you need to double the backslash (`\\s`).  
To fix this, replace all instances of `\s` with `\\s` within the string template passed to `RegExp`. In the specific code, `` new RegExp(`^${escaped}\s*[-–—·:：]*\s*`, 'i') `` should become `` new RegExp(`^${escaped}\\s*[-–—·:：]*\\s*`, 'i') ``. This ensures that the intended regex pattern matches whitespace at the expected places.

Edit only the affected line (line 955), keeping surrounding code intact. No new imports, methods, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
