### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/Better-Names-for-7FA4/content/main.js
+++ b/Better-Names-for-7FA4/content/main.js
@@ -1004,10 +1004,14 @@ window.getCurrentUserId = getCurrentUserId;
     entries.forEach(({ displayCode, name }) => {
       const li = document.createElement('li');
       li.className = 'plan-preview-item';
-      li.innerHTML = `
-        <span class="plan-preview-code">${displayCode}</span>
-        <span class="plan-preview-name">${name}</span>
-      `;
+      const codeSpan = document.createElement('span');
+      codeSpan.className = 'plan-preview-code';
+      codeSpan.textContent = displayCode;
+      const nameSpan = document.createElement('span');
+      nameSpan.className = 'plan-preview-name';
+      nameSpan.textContent = name;
+      li.appendChild(codeSpan);
+      li.appendChild(nameSpan);
       listEl.appendChild(li);
     });
     listEl.style.display = entries.length ? 'flex' : 'none';


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/15](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/15)

The vulnerability arises because untrusted data (`displayCode` and `name`) are used in a string assigned to `element.innerHTML`, which interprets the content as HTML, allowing malicious input to produce scriptable or otherwise dangerous output. The simplest and most robust fix is to never use untrusted data in `innerHTML`. Instead, insert untrusted content using `textContent`, which will not interpret meta-characters as HTML/tags.

The fix is to:
- Replace the usage of `li.innerHTML = ...` (lines 1007–1010) with DOM manipulation: create the respective child `<span>` elements, set their `textContent` property to `displayCode` and `name` respectively, then append them to the `li`.
- This change should be done in `renderPlanPreview`, specifically replacing the block:
    ```js
    li.innerHTML = `
      <span class="plan-preview-code">${displayCode}</span>
      <span class="plan-preview-name">${name}</span>
    `;
    ```
  with code that creates the spans, sets their `textContent`, and appends them.
- No new methods or imports are needed; just basic DOM API usage.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
