### PR TITLE
Sanitize markdown output to prevent XSS on review tag pages

### DIFF
--- a/Better-Names-for-7FA4/content/render_logic.js
+++ b/Better-Names-for-7FA4/content/render_logic.js
@@ -89,6 +89,39 @@ function restoreMathSegments(text, segments) {
   return output;
 }
 
+function sanitizeHtml(unsafeHtml) {
+  const template = document.createElement('template');
+  template.innerHTML = unsafeHtml;
+
+  const blockedTags = ['script', 'iframe', 'object', 'embed', 'link', 'meta', 'base', 'form'];
+  blockedTags.forEach((tag) => {
+    template.content.querySelectorAll(tag).forEach((node) => node.remove());
+  });
+
+  template.content.querySelectorAll('*').forEach((node) => {
+    Array.from(node.attributes).forEach(({ name, value }) => {
+      const attrName = name.toLowerCase();
+      if (attrName.startsWith('on') || attrName === 'srcdoc' || attrName === 'style') {
+        node.removeAttribute(name);
+        return;
+      }
+
+      if (attrName === 'href' || attrName === 'src' || attrName === 'xlink:href') {
+        const normalizedValue = (value || '').trim().toLowerCase();
+        if (
+          normalizedValue.startsWith('javascript:') ||
+          normalizedValue.startsWith('data:text/html') ||
+          normalizedValue.startsWith('data:image/svg')
+        ) {
+          node.removeAttribute(name);
+        }
+      }
+    });
+  });
+
+  return template.innerHTML;
+}
+
 // 1. 定义执行函数
 function doRender() {
   const elements = document.querySelectorAll(targetSelector);
@@ -110,7 +143,8 @@ function doRender() {
         ? protectMathSegments(text)
         : { placeholderText: text, segments: [] };
       const htmlResult = marked.parse(placeholderText);
-      el.innerHTML = restoreMathSegments(htmlResult, segments);
+      const restoredHtml = restoreMathSegments(htmlResult, segments);
+      el.innerHTML = sanitizeHtml(restoredHtml);
     }
 
     // --- 处理 LaTeX ---


### PR DESCRIPTION
### Motivation
- The extension's content script is injected on `/review/user_tags/html?tag_id=*` pages and previously assigned `marked.parse` output directly to `innerHTML`, which permits attacker-controlled markup to execute as script and enables XSS.
- A minimal in-place remediation is needed to remove dangerous elements/attributes while preserving existing Markdown and KaTeX rendering behavior.

### Description
- Added a lightweight sanitizer `sanitizeHtml()` in `content/render_logic.js` that removes dangerous tags (`script`, `iframe`, `object`, `embed`, `link`, `meta`, `base`, `form`) and strips inline event handlers, `style`, `srcdoc`, and other unsafe attributes.
- The sanitizer also removes unsafe URL schemes on `href`/`src`/`xlink:href` attributes such as `javascript:` and risky `data:` payloads before DOM injection.
- Integrated the sanitizer into the markdown rendering flow by running `sanitizeHtml(restoreMathSegments(...))` before assigning to `el.innerHTML`, while preserving math segment protection and KaTeX rendering.

### Testing
- Ran syntax check `node --check Better-Names-for-7FA4/content/render_logic.js`, which completed without errors.
- Verified the local diff to confirm `sanitizeHtml()` was added and the markdown rendering assignment now calls `sanitizeHtml(...)` instead of assigning raw HTML.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab5b65509483299a8712a6b3bdbdea)