### PR TITLE
Sanitize untrusted Markdown input to prevent stored XSS on user_plans pages

### DIFF
--- a/Better-Names-for-7FA4/content/render_logic.js
+++ b/Better-Names-for-7FA4/content/render_logic.js
@@ -89,6 +89,15 @@ function restoreMathSegments(text, segments) {
   return output;
 }
 
+function escapeHtml(text) {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 // 1. 定义执行函数
 function doRender() {
   const elements = document.querySelectorAll(targetSelector);
@@ -109,7 +118,8 @@ function doRender() {
       const { placeholderText, segments } = hasMath
         ? protectMathSegments(text)
         : { placeholderText: text, segments: [] };
-      const htmlResult = marked.parse(placeholderText);
+      const safeMarkdownText = escapeHtml(placeholderText);
+      const htmlResult = marked.parse(safeMarkdownText);
       el.innerHTML = restoreMathSegments(htmlResult, segments);
     }
 


### PR DESCRIPTION
### Motivation
- The content script parsed user-controlled `<pre>` text with `marked.parse` and wrote the result to `innerHTML`, allowing stored XSS when plan text contains HTML/JS.

### Description
- Add an `escapeHtml` helper in `content/render_logic.js` that escapes `&`, `<`, `>`, `"`, and `'` to neutralize raw HTML.
- Apply `escapeHtml` to the Markdown source (while preserving math placeholders) before calling `marked.parse`, then restore math segments so KaTeX rendering still works.
- Preserve the original markdown/math detection and rendering flow while ensuring attacker-supplied HTML renders as plain text instead of executable DOM.

### Testing
- Confirmed the new helper is present with `node -e "const fs=require('fs'); console.log(fs.readFileSync('Better-Names-for-7FA4/content/render_logic.js','utf8').includes('function escapeHtml'))"` which returned `true`.
- Validated behavior with `node -e "const marked=require('./Better-Names-for-7FA4/content/libs/marked.min.js'); const escapeHtml=t=>t.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\"/g,'&quot;').replace(/'/g,'&#39;'); console.log(marked.parse(escapeHtml('**bold** <img src=x onerror=alert(1)>')).trim())"` which produced `<p><strong>bold</strong> &lt;img src=x onerror=alert(1)&gt;</p>`, confirming HTML is escaped and not executable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ab5be19f548329b526bebdb714e9d5)