### PR TITLE
Prevent DOM XSS by inserting user/title text as text nodes

### DIFF
--- a/Better-Names-for-7FA4/content/panel/panel.js
+++ b/Better-Names-for-7FA4/content/panel/panel.js
@@ -3676,10 +3676,10 @@
     }
 
     const limitedName = truncateByUnits(combinedName || '', maxUserUnits);
-    const finalText = (img ? '\u00A0' : '') + escapeHtml(limitedName);
+    const finalText = (img ? '\u00A0' : '') + limitedName;
 
     Array.from(a.childNodes).forEach(n => { if (n.nodeType === Node.TEXT_NODE) n.remove(); });
-    a.insertAdjacentHTML('beforeend', finalText);
+    a.appendChild(document.createTextNode(finalText));
     renderUserTags(a, info?.tags);
   }
 
@@ -3687,9 +3687,7 @@
     if (!span || !span.matches('#vueAppFuckSafari > tbody > tr > td:nth-child(2) > a > span')) return;
     if (!markOnce(span, 'TitleDone')) return;
 
-    let prefix = '';
     const b = span.querySelector('b');
-    if (b) prefix = b.outerHTML + ' ';
 
     let text = '';
     span.childNodes.forEach(n => { if (n.nodeType === Node.TEXT_NODE) text += n.textContent; });
@@ -3698,7 +3696,7 @@
 
     const truncated = truncateByUnits(text, maxTitleUnits);
     Array.from(span.childNodes).forEach(n => { if (n.nodeType === Node.TEXT_NODE) n.remove(); });
-    span.innerHTML = prefix + truncated;
+    span.appendChild(document.createTextNode((b ? ' ' : '') + truncated));
 
     // BN PATCH: force uniform font size on submissions page when title truncation is enabled
     try {


### PR DESCRIPTION
### Motivation
- The content rendering logic read usernames and problem titles from DOM text nodes and reinserted them using HTML sinks (`insertAdjacentHTML` / `innerHTML`), allowing stored DOM XSS if those strings contained markup. 
- The vulnerable logic was present in the repository HEAD in `Better-Names-for-7FA4/content/panel/panel.js` and required a minimal, safe remediation.

### Description
- Replaced `a.insertAdjacentHTML('beforeend', finalText)` in `processUserLink` with `a.appendChild(document.createTextNode(finalText))` so username text is never parsed as HTML. 
- Replaced `span.innerHTML = prefix + truncated` in `processProblemTitle` with `span.appendChild(document.createTextNode((b ? ' ' : '') + truncated))` so truncated titles are inserted as text nodes rather than markup. 
- Kept prior behaviors such as avatar spacing (`\u00A0`), `<b>` prefix preservation, truncation via `truncateByUnits`, color styling, and user tag rendering while removing unsafe HTML sinks.

### Testing
- Ran `node --check Better-Names-for-7FA4/content/panel/panel.js` and the syntax check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af91545b9c832988d3a744dd046da0)