### PR TITLE
Remove localStorage-backed GM values to prevent stored DOM XSS

### DIFF
--- a/Better-Names-for-7FA4/content/gm-shim.js
+++ b/Better-Names-for-7FA4/content/gm-shim.js
@@ -17,21 +17,20 @@
     } catch (e) { cb({}); }
   }
 
+  const gmStore = Object.create(null);
+
   function gmLocalGet(key, defVal) {
     try {
-      const k = "__gm__" + key;
-      const v = localStorage.getItem(k);
-      if (v === null || v === undefined) return defVal;
-      try { return JSON.parse(v); } catch { return v; }
+      if (!Object.prototype.hasOwnProperty.call(gmStore, key)) return defVal;
+      const value = gmStore[key];
+      return value === undefined ? defVal : value;
     } catch (e) {
       return defVal;
     }
   }
   function gmLocalSet(key, value) {
     try {
-      const k = "__gm__" + key;
-      const v = (typeof value === 'string') ? value : JSON.stringify(value);
-      localStorage.setItem(k, v);
+      gmStore[key] = value;
       mirrorToChromeStorage(key, value);
     } catch (e) {}
   }
@@ -42,13 +41,7 @@
         try {
           if (all) {
             Object.keys(all).forEach(k => {
-              const lk = "__gm__" + k;
-              const v = all[k];
-              if (v === undefined) {
-                localStorage.removeItem(lk);
-              } else {
-                localStorage.setItem(lk, (typeof v === 'string') ? v : JSON.stringify(v));
-              }
+              gmStore[k] = all[k];
             });
           }
         } catch (e) {}


### PR DESCRIPTION
### Motivation
- The GM shim stored `GM_getValue`/`GM_setValue` data in page-origin `localStorage`, which is writable by page scripts and enabled a persistent DOM XSS when those values were later interpolated into `innerHTML` templates.
- The intent is to remove the attacker-controlled storage surface while preserving extension persistence and functionality.

### Description
- Replaced `localStorage` backing with an internal in-memory store `gmStore` in `Better-Names-for-7FA4/content/gm-shim.js` and updated `gmLocalGet`/`gmLocalSet` to read/write from `gmStore` instead of `localStorage`.
- Kept persistence integration with extension storage by mirroring writes via `mirrorToChromeStorage` and hydrating `gmStore` from `chrome.storage.local` on startup instead of populating `localStorage`.
- Removed all direct `localStorage` reads/writes used for GM values, eliminating the `__gm__*` page-controlled injection path.
- Preserved existing API surface (`window.GM_getValue`, `window.GM_setValue`, and async `window.GM.*` aliases) so calling code remains unchanged.

### Testing
- Ran `node --check Better-Names-for-7FA4/content/gm-shim.js` which completed successfully.
- Verified there are no remaining direct `localStorage` operations for GM values with `rg -n "localStorage\.(getItem|setItem|removeItem)" Better-Names-for-7FA4/content/gm-shim.js`, which returned no matches.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69af900172e48329ba523caa96656c10)