### PR TITLE
Potential fix for code scanning alert no. 22: Incomplete URL scheme check

### DIFF
--- a/Better-Names-for-7FA4/content/render_logic.js
+++ b/Better-Names-for-7FA4/content/render_logic.js
@@ -110,10 +110,18 @@ function sanitizeHtml(unsafeHtml) {
         const normalizedValue = (value || '').trim().toLowerCase();
         if (
           normalizedValue.startsWith('javascript:') ||
-          normalizedValue.startsWith('data:text/html') ||
-          normalizedValue.startsWith('data:image/svg')
+          normalizedValue.startsWith('vbscript:') ||
+          normalizedValue.startsWith('data:')
         ) {
-          node.removeAttribute(name);
+          const isSafeImageData =
+            normalizedValue.startsWith('data:image/png') ||
+            normalizedValue.startsWith('data:image/jpeg') ||
+            normalizedValue.startsWith('data:image/jpg') ||
+            normalizedValue.startsWith('data:image/gif') ||
+            normalizedValue.startsWith('data:image/webp');
+          if (!isSafeImageData) {
+            node.removeAttribute(name);
+          }
         }
       }
     });


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/22](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/22)

In general, the fix is to make the URL scheme validation comprehensive for executable schemes: block `javascript:`, `vbscript:`, and all `data:` schemes that can carry active content, instead of hard-coding only a few `data:` prefixes. The normalization step is already present (trim and lowercase), so we only need to expand the conditional that decides whether to remove the attribute.

The best targeted fix here is within `sanitizeHtml` in `Better-Names-for-7FA4/content/render_logic.js`, lines 109–115. Replace the current three-condition `if` that checks for `javascript:`, `data:text/html`, and `data:image/svg` with a more complete set: block `javascript:` and `vbscript:` schemes unconditionally, and block any `data:` URI that is not clearly a safe, non-scriptable type (for example, keep allowing common image types like `data:image/png`, `data:image/jpeg`, `data:image/gif`, and `data:image/webp` while blocking everything else). This preserves legitimate embedded images but closes the gap for other `data:` payloads.

No extra imports or helper functions are required; the fix can be expressed inline using additional `startsWith` checks and a small allowlist for safe `data:` image MIME types.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
