### PR TITLE
Potential fix for code scanning alert no. 24: DOM text reinterpreted as HTML

### DIFF
--- a/Better-Names-for-7FA4/content/panel/panel.js
+++ b/Better-Names-for-7FA4/content/panel/panel.js
@@ -6909,8 +6909,16 @@
 
     document.addEventListener('click', (e) => {
         if (e.target.classList.contains('bn-img-lazy')) {
-            e.target.src = e.target.getAttribute("data-src");
-            access_src.set(e.target.src, true);
+            const rawSrc = e.target.getAttribute("data-src");
+            let safeSrc = null;
+            try {
+                const parsed = new URL(rawSrc, window.location.href);
+                if (parsed.protocol === 'http:' || parsed.protocol === 'https:') safeSrc = parsed.href;
+            } catch (e) {
+            }
+            if (!safeSrc) return;
+            e.target.src = safeSrc;
+            access_src.set(safeSrc, true);
             e.target.classList.remove('bn-img-lazy');
             e.target.parentElement.removeAttribute("data-tooltip");
         }


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/24](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/24)

Best fix: validate and normalize `data-src` before assigning it to `e.target.src`, allowing only safe URL schemes (typically `http:` and `https:`) and optionally same-origin relative URLs. Reject anything else.

In `Better-Names-for-7FA4/content/panel/panel.js`, update the click handler block around lines 6911–6914:

- Read `data-src` into a temporary variable.
- Parse with `new URL(raw, window.location.href)` inside `try/catch`.
- Allow only `http:`/`https:` protocols.
- Assign only validated URL (`safeSrc`) to `e.target.src`.
- Update `access_src` with the validated URL, not raw input.
- If invalid, return early without changing DOM state.

No new dependency is needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
