### PR TITLE
Potential fix for code scanning alert no. 19: Incomplete string escaping or encoding

### DIFF
--- a/Better-Names-for-7FA4/content/libs/katex/katex.mjs
+++ b/Better-Names-for-7FA4/content/libs/katex/katex.mjs
@@ -11902,7 +11902,7 @@ var mathmlBuilder$3 = (group, options) => {
     var withDelims = [];
 
     if (group.leftDelim != null) {
-      var leftOp = new mathMLTree.MathNode("mo", [new mathMLTree.TextNode(group.leftDelim.replace("\\", ""))]);
+      var leftOp = new mathMLTree.MathNode("mo", [new mathMLTree.TextNode(group.leftDelim.replace(/\\/g, ""))]);
       leftOp.setAttribute("fence", "true");
       withDelims.push(leftOp);
     }
@@ -11910,7 +11910,7 @@ var mathmlBuilder$3 = (group, options) => {
     withDelims.push(node);
 
     if (group.rightDelim != null) {
-      var rightOp = new mathMLTree.MathNode("mo", [new mathMLTree.TextNode(group.rightDelim.replace("\\", ""))]);
+      var rightOp = new mathMLTree.MathNode("mo", [new mathMLTree.TextNode(group.rightDelim.replace(/\\/g, ""))]);
       rightOp.setAttribute("fence", "true");
       withDelims.push(rightOp);
     }


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/19](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/19)

Use a global regular expression so **all** backslashes are removed, not just the first one.

Best minimal fix (without changing functionality) is in `Better-Names-for-7FA4/content/libs/katex/katex.mjs` at the two delimiter normalization sites in `mathmlBuilder$3`:
- Change `group.leftDelim.replace("\\", "")` to `group.leftDelim.replace(/\\/g, "")`
- Change `group.rightDelim.replace("\\", "")` to `group.rightDelim.replace(/\\/g, "")`

No imports or new helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
