### PR TITLE
Potential fix for code scanning alert no. 16: Incomplete string escaping or encoding

### DIFF
--- a/Better-Names-for-7FA4/content/libs/katex/katex.mjs
+++ b/Better-Names-for-7FA4/content/libs/katex/katex.mjs
@@ -11229,7 +11229,7 @@ defineEnvironment({
       "Bmatrix": ["\\{", "\\}"],
       "vmatrix": ["|", "|"],
       "Vmatrix": ["\\Vert", "\\Vert"]
-    }[context.envName.replace("*", "")]; // \hskip -\arraycolsep in amsmath
+    }[context.envName.replace(/\*/g, "")]; // \hskip -\arraycolsep in amsmath
 
     var colAlign = "c";
     var payload = {


### PR DESCRIPTION
Potential fix for [https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/16](https://github.com/DestinyleSnowy/Better-Names-for-7FA4/security/code-scanning/16)

Use a global replacement so all `*` characters are removed when deriving the base environment name. This preserves current functionality for valid names (single trailing `*`) and makes the code robust against malformed/unexpected names.

Best single change:
- In `Better-Names-for-7FA4/content/libs/katex/katex.mjs`, at the `delimiters` lookup line in the `handler(context)` for matrix environments, replace:
  - `context.envName.replace("*", "")`
  with:
  - `context.envName.replace(/\*/g, "")`

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
